### PR TITLE
add comment to example codes

### DIFF
--- a/examples/echo_bot/server.go
+++ b/examples/echo_bot/server.go
@@ -53,6 +53,8 @@ func main() {
 			}
 		}
 	})
+	// This is just a sample code.
+	// For actually use, you must support HTTPS by using `ListenAndServeTLS`, reverse proxy or etc.
 	if err := http.ListenAndServe(":"+os.Getenv("PORT"), nil); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/echo_bot_handler/server.go
+++ b/examples/echo_bot_handler/server.go
@@ -49,8 +49,9 @@ func main() {
 			}
 		}
 	})
-
 	http.Handle("/callback", handler)
+	// This is just a sample code.
+	// For actually use, you must support HTTPS by using `ListenAndServeTLS`, reverse proxy or etc.
 	if err := http.ListenAndServe(":"+os.Getenv("PORT"), nil); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/kitchensink/server.go
+++ b/examples/kitchensink/server.go
@@ -44,6 +44,8 @@ func main() {
 	http.HandleFunc("/downloaded/", http.StripPrefix("/downloaded/", downloadedFileServer).ServeHTTP)
 
 	http.HandleFunc("/callback", app.Callback)
+	// This is just a sample code.
+	// For actually use, you must support HTTPS by using `ListenAndServeTLS`, reverse proxy or etc.
 	if err := http.ListenAndServe(":"+os.Getenv("PORT"), nil); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
ref. #20 
It is better to use `ListenAndServeTLS` method, but it is a just a sample code and should be simple. So I added comments about the actual use.