### PR TITLE
make ThumbnailImageURL optional

### DIFF
--- a/linebot/send_message_test.go
+++ b/linebot/send_message_test.go
@@ -121,6 +121,72 @@ func TestPushMessages(t *testing.T) {
 			},
 		},
 		{
+			// A buttons template message without thumbnailImageURL
+			Messages: []Message{
+				NewTemplateMessage(
+					"this is a buttons template",
+					NewButtonsTemplate(
+						"",
+						"Menu",
+						"Please select",
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", ""),
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", "text"),
+						NewURITemplateAction("View detail", "http://example.com/page/123"),
+					),
+				),
+			},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"to":"U0cc15697597f61dd8b01cea8b027050e","messages":[{"type":"template","altText":"this is a buttons template","template":{"type":"buttons","title":"Menu","text":"Please select","actions":[{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123"},{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123","text":"text"},{"type":"uri","label":"View detail","uri":"http://example.com/page/123"}]}}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
+			// A buttons template message without title
+			Messages: []Message{
+				NewTemplateMessage(
+					"this is a buttons template",
+					NewButtonsTemplate(
+						"https://example.com/bot/images/image.jpg",
+						"",
+						"Please select",
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", ""),
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", "text"),
+						NewURITemplateAction("View detail", "http://example.com/page/123"),
+					),
+				),
+			},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"to":"U0cc15697597f61dd8b01cea8b027050e","messages":[{"type":"template","altText":"this is a buttons template","template":{"type":"buttons","thumbnailImageUrl":"https://example.com/bot/images/image.jpg","text":"Please select","actions":[{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123"},{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123","text":"text"},{"type":"uri","label":"View detail","uri":"http://example.com/page/123"}]}}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
+			// A buttons template message without thumbnailImageURL and title
+			Messages: []Message{
+				NewTemplateMessage(
+					"this is a buttons template",
+					NewButtonsTemplate(
+						"",
+						"",
+						"Please select",
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", ""),
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", "text"),
+						NewURITemplateAction("View detail", "http://example.com/page/123"),
+					),
+				),
+			},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"to":"U0cc15697597f61dd8b01cea8b027050e","messages":[{"type":"template","altText":"this is a buttons template","template":{"type":"buttons","text":"Please select","actions":[{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123"},{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123","text":"text"},{"type":"uri","label":"View detail","uri":"http://example.com/page/123"}]}}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
 			// A confirm template message
 			Messages: []Message{
 				NewTemplateMessage(

--- a/linebot/template.go
+++ b/linebot/template.go
@@ -56,7 +56,7 @@ type ButtonsTemplate struct {
 func (t *ButtonsTemplate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type              TemplateType     `json:"type"`
-		ThumbnailImageURL string           `json:"thumbnailImageUrl"`
+		ThumbnailImageURL string           `json:"thumbnailImageUrl,omitempty"`
 		Title             string           `json:"title,omitempty"`
 		Text              string           `json:"text"`
 		Actions           []TemplateAction `json:"actions"`
@@ -95,7 +95,7 @@ type CarouselTemplate struct {
 
 // CarouselColumn type
 type CarouselColumn struct {
-	ThumbnailImageURL string           `json:"thumbnailImageUrl"`
+	ThumbnailImageURL string           `json:"thumbnailImageUrl,omitempty"`
 	Title             string           `json:"title,omitempty"`
 	Text              string           `json:"text"`
 	Actions           []TemplateAction `json:"actions"`
@@ -126,6 +126,7 @@ func NewConfirmTemplate(text string, left, right TemplateAction) *ConfirmTemplat
 }
 
 // NewButtonsTemplate function
+// `thumbnailImageURL` and `title` are optional. they can be empty.
 func NewButtonsTemplate(thumbnailImageURL, title, text string, actions ...TemplateAction) *ButtonsTemplate {
 	return &ButtonsTemplate{
 		ThumbnailImageURL: thumbnailImageURL,
@@ -143,6 +144,7 @@ func NewCarouselTemplate(columns ...*CarouselColumn) *CarouselTemplate {
 }
 
 // NewCarouselColumn function
+// `thumbnailImageURL` and `title` are optional. they can be empty.
 func NewCarouselColumn(thumbnailImageURL, title, text string, actions ...TemplateAction) *CarouselColumn {
 	return &CarouselColumn{
 		ThumbnailImageURL: thumbnailImageURL,


### PR DESCRIPTION
ref. #24 
added `omitempty` annotation to `ThumbnailImageURL` because `thumbnailImageURL` of `ButtonsTemplate` and `CarouselColumn` is optional.