### PR TITLE
Add WithImageOptions for buttons/carousel templates

### DIFF
--- a/linebot/send_message_test.go
+++ b/linebot/send_message_test.go
@@ -187,6 +187,28 @@ func TestPushMessages(t *testing.T) {
 			},
 		},
 		{
+			// A buttons template message without title, with image options
+			Messages: []Message{
+				NewTemplateMessage(
+					"this is a buttons template",
+					NewButtonsTemplate(
+						"https://example.com/bot/images/image.jpg",
+						"",
+						"Please select",
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", ""),
+						NewPostbackTemplateAction("Buy", "action=buy&itemid=123", "text"),
+						NewURITemplateAction("View detail", "http://example.com/page/123"),
+					).WithImageOptions("rectangle", "cover", "#FFFFFF"),
+				),
+			},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"to":"U0cc15697597f61dd8b01cea8b027050e","messages":[{"type":"template","altText":"this is a buttons template","template":{"type":"buttons","thumbnailImageUrl":"https://example.com/bot/images/image.jpg","imageAspectRatio":"rectangle","imageSize":"cover","imageBackgroundColor":"#FFFFFF","text":"Please select","actions":[{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123"},{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=123","text":"text"},{"type":"uri","label":"View detail","uri":"http://example.com/page/123"}]}}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
 			// A buttons template message without thumbnailImageURL and title
 			Messages: []Message{
 				NewTemplateMessage(
@@ -248,6 +270,30 @@ func TestPushMessages(t *testing.T) {
 			Response:     []byte(`{}`),
 			Want: want{
 				RequestBody: []byte(`{"to":"U0cc15697597f61dd8b01cea8b027050e","messages":[{"type":"template","altText":"this is a carousel template","template":{"type":"carousel","columns":[{"thumbnailImageUrl":"https://example.com/bot/images/item1.jpg","title":"this is menu","text":"description","actions":[{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=111"},{"type":"postback","label":"Add to cart","data":"action=add\u0026itemid=111"},{"type":"uri","label":"View detail","uri":"http://example.com/page/111"}]}]}}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
+			// A carousel template message, with new image options
+			Messages: []Message{
+				NewTemplateMessage(
+					"this is a carousel template with imageAspectRatio, imageSize and imageBackgroundColor",
+					NewCarouselTemplate(
+						NewCarouselColumn(
+							"https://example.com/bot/images/item1.jpg",
+							"this is menu",
+							"description",
+							NewPostbackTemplateAction("Buy", "action=buy&itemid=111", ""),
+							NewPostbackTemplateAction("Add to cart", "action=add&itemid=111", ""),
+							NewURITemplateAction("View detail", "http://example.com/page/111"),
+						).WithImageOptions("#FFFFFF"),
+					).WithImageOptions("rectangle", "cover"),
+				),
+			},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"to":"U0cc15697597f61dd8b01cea8b027050e","messages":[{"type":"template","altText":"this is a carousel template with imageAspectRatio, imageSize and imageBackgroundColor","template":{"type":"carousel","columns":[{"thumbnailImageUrl":"https://example.com/bot/images/item1.jpg","imageBackgroundColor":"#FFFFFF","title":"this is menu","text":"description","actions":[{"type":"postback","label":"Buy","data":"action=buy\u0026itemid=111"},{"type":"postback","label":"Add to cart","data":"action=add\u0026itemid=111"},{"type":"uri","label":"View detail","uri":"http://example.com/page/111"}]}],"imageAspectRatio":"rectangle","imageSize":"cover"}}]}` + "\n"),
 				Response:    &BasicResponse{},
 			},
 		},

--- a/linebot/template.go
+++ b/linebot/template.go
@@ -48,27 +48,44 @@ type Template interface {
 
 // ButtonsTemplate type
 type ButtonsTemplate struct {
-	ThumbnailImageURL string
-	Title             string
-	Text              string
-	Actions           []TemplateAction
+	ThumbnailImageURL    string
+	ImageAspectRatio     string
+	ImageSize            string
+	ImageBackgroundColor string
+	Title                string
+	Text                 string
+	Actions              []TemplateAction
 }
 
 // MarshalJSON method of ButtonsTemplate
 func (t *ButtonsTemplate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type              TemplateType     `json:"type"`
-		ThumbnailImageURL string           `json:"thumbnailImageUrl,omitempty"`
-		Title             string           `json:"title,omitempty"`
-		Text              string           `json:"text"`
-		Actions           []TemplateAction `json:"actions"`
+		Type                 TemplateType     `json:"type"`
+		ThumbnailImageURL    string           `json:"thumbnailImageUrl,omitempty"`
+		ImageAspectRatio     string           `json:"imageAspectRatio,omitempty"`
+		ImageSize            string           `json:"imageSize,omitempty"`
+		ImageBackgroundColor string           `json:"imageBackgroundColor,omitempty"`
+		Title                string           `json:"title,omitempty"`
+		Text                 string           `json:"text"`
+		Actions              []TemplateAction `json:"actions"`
 	}{
-		Type:              TemplateTypeButtons,
-		ThumbnailImageURL: t.ThumbnailImageURL,
-		Title:             t.Title,
-		Text:              t.Text,
-		Actions:           t.Actions,
+		Type:                 TemplateTypeButtons,
+		ThumbnailImageURL:    t.ThumbnailImageURL,
+		ImageAspectRatio:     t.ImageAspectRatio,
+		ImageSize:            t.ImageSize,
+		ImageBackgroundColor: t.ImageBackgroundColor,
+		Title:                t.Title,
+		Text:                 t.Text,
+		Actions:              t.Actions,
 	})
+}
+
+// WithImageOptions method, ButtonsTemplate can set imageAspectRatio, imageSize and imageBackgroundColor
+func (t *ButtonsTemplate) WithImageOptions(imageAspectRatio, imageSize, imageBackgroundColor string) *ButtonsTemplate {
+	t.ImageAspectRatio = imageAspectRatio
+	t.ImageSize = imageSize
+	t.ImageBackgroundColor = imageBackgroundColor
+	return t
 }
 
 // ConfirmTemplate type
@@ -92,26 +109,46 @@ func (t *ConfirmTemplate) MarshalJSON() ([]byte, error) {
 
 // CarouselTemplate type
 type CarouselTemplate struct {
-	Columns []*CarouselColumn
+	Columns          []*CarouselColumn
+	ImageAspectRatio string
+	ImageSize        string
 }
 
 // CarouselColumn type
 type CarouselColumn struct {
-	ThumbnailImageURL string           `json:"thumbnailImageUrl,omitempty"`
-	Title             string           `json:"title,omitempty"`
-	Text              string           `json:"text"`
-	Actions           []TemplateAction `json:"actions"`
+	ThumbnailImageURL    string           `json:"thumbnailImageUrl,omitempty"`
+	ImageBackgroundColor string           `json:"imageBackgroundColor,omitempty"`
+	Title                string           `json:"title,omitempty"`
+	Text                 string           `json:"text"`
+	Actions              []TemplateAction `json:"actions"`
 }
 
 // MarshalJSON method of CarouselTemplate
 func (t *CarouselTemplate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type    TemplateType      `json:"type"`
-		Columns []*CarouselColumn `json:"columns"`
+		Type             TemplateType      `json:"type"`
+		Columns          []*CarouselColumn `json:"columns"`
+		ImageAspectRatio string            `json:"imageAspectRatio,omitempty"`
+		ImageSize        string            `json:"imageSize,omitempty"`
 	}{
-		Type:    TemplateTypeCarousel,
-		Columns: t.Columns,
+		Type:             TemplateTypeCarousel,
+		Columns:          t.Columns,
+		ImageAspectRatio: t.ImageAspectRatio,
+		ImageSize:        t.ImageSize,
 	})
+}
+
+// WithImageOptions method, CarouselTemplate can set imageAspectRatio and imageSize
+func (t *CarouselTemplate) WithImageOptions(imageAspectRatio, imageSize string) *CarouselTemplate {
+	t.ImageAspectRatio = imageAspectRatio
+	t.ImageSize = imageSize
+	return t
+}
+
+// WithImageOptions method, CarouselColumn can set imageBackgroundColor
+func (t *CarouselColumn) WithImageOptions(imageBackgroundColor string) *CarouselColumn {
+	t.ImageBackgroundColor = imageBackgroundColor
+	return t
 }
 
 // ImageCarouselTemplate type

--- a/linebot/template.go
+++ b/linebot/template.go
@@ -40,6 +40,24 @@ const (
 	TemplateActionTypeDatetimePicker TemplateActionType = "datetimepicker"
 )
 
+// ImageAspectRatioType type
+type ImageAspectRatioType string
+
+// ImageAspectRatioType constants
+const (
+	ImageAspectRatioTypeRectangle ImageAspectRatioType = "rectangle"
+	ImageAspectRatioTypeSquare    ImageAspectRatioType = "square"
+)
+
+// ImageSizeType type
+type ImageSizeType string
+
+// ImageSizeType constants
+const (
+	ImageSizeTypeCover   ImageSizeType = "cover"
+	ImageSizeTypeContain ImageSizeType = "contain"
+)
+
 // Template interface
 type Template interface {
 	json.Marshaler
@@ -49,8 +67,8 @@ type Template interface {
 // ButtonsTemplate type
 type ButtonsTemplate struct {
 	ThumbnailImageURL    string
-	ImageAspectRatio     string
-	ImageSize            string
+	ImageAspectRatio     ImageAspectRatioType
+	ImageSize            ImageSizeType
 	ImageBackgroundColor string
 	Title                string
 	Text                 string
@@ -60,14 +78,14 @@ type ButtonsTemplate struct {
 // MarshalJSON method of ButtonsTemplate
 func (t *ButtonsTemplate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type                 TemplateType     `json:"type"`
-		ThumbnailImageURL    string           `json:"thumbnailImageUrl,omitempty"`
-		ImageAspectRatio     string           `json:"imageAspectRatio,omitempty"`
-		ImageSize            string           `json:"imageSize,omitempty"`
-		ImageBackgroundColor string           `json:"imageBackgroundColor,omitempty"`
-		Title                string           `json:"title,omitempty"`
-		Text                 string           `json:"text"`
-		Actions              []TemplateAction `json:"actions"`
+		Type                 TemplateType         `json:"type"`
+		ThumbnailImageURL    string               `json:"thumbnailImageUrl,omitempty"`
+		ImageAspectRatio     ImageAspectRatioType `json:"imageAspectRatio,omitempty"`
+		ImageSize            ImageSizeType        `json:"imageSize,omitempty"`
+		ImageBackgroundColor string               `json:"imageBackgroundColor,omitempty"`
+		Title                string               `json:"title,omitempty"`
+		Text                 string               `json:"text"`
+		Actions              []TemplateAction     `json:"actions"`
 	}{
 		Type:                 TemplateTypeButtons,
 		ThumbnailImageURL:    t.ThumbnailImageURL,
@@ -81,7 +99,7 @@ func (t *ButtonsTemplate) MarshalJSON() ([]byte, error) {
 }
 
 // WithImageOptions method, ButtonsTemplate can set imageAspectRatio, imageSize and imageBackgroundColor
-func (t *ButtonsTemplate) WithImageOptions(imageAspectRatio, imageSize, imageBackgroundColor string) *ButtonsTemplate {
+func (t *ButtonsTemplate) WithImageOptions(imageAspectRatio ImageAspectRatioType, imageSize ImageSizeType, imageBackgroundColor string) *ButtonsTemplate {
 	t.ImageAspectRatio = imageAspectRatio
 	t.ImageSize = imageSize
 	t.ImageBackgroundColor = imageBackgroundColor
@@ -110,8 +128,8 @@ func (t *ConfirmTemplate) MarshalJSON() ([]byte, error) {
 // CarouselTemplate type
 type CarouselTemplate struct {
 	Columns          []*CarouselColumn
-	ImageAspectRatio string
-	ImageSize        string
+	ImageAspectRatio ImageAspectRatioType
+	ImageSize        ImageSizeType
 }
 
 // CarouselColumn type
@@ -126,10 +144,10 @@ type CarouselColumn struct {
 // MarshalJSON method of CarouselTemplate
 func (t *CarouselTemplate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type             TemplateType      `json:"type"`
-		Columns          []*CarouselColumn `json:"columns"`
-		ImageAspectRatio string            `json:"imageAspectRatio,omitempty"`
-		ImageSize        string            `json:"imageSize,omitempty"`
+		Type             TemplateType         `json:"type"`
+		Columns          []*CarouselColumn    `json:"columns"`
+		ImageAspectRatio ImageAspectRatioType `json:"imageAspectRatio,omitempty"`
+		ImageSize        ImageSizeType        `json:"imageSize,omitempty"`
 	}{
 		Type:             TemplateTypeCarousel,
 		Columns:          t.Columns,
@@ -139,7 +157,7 @@ func (t *CarouselTemplate) MarshalJSON() ([]byte, error) {
 }
 
 // WithImageOptions method, CarouselTemplate can set imageAspectRatio and imageSize
-func (t *CarouselTemplate) WithImageOptions(imageAspectRatio, imageSize string) *CarouselTemplate {
+func (t *CarouselTemplate) WithImageOptions(imageAspectRatio ImageAspectRatioType, imageSize ImageSizeType) *CarouselTemplate {
 	t.ImageAspectRatio = imageAspectRatio
 	t.ImageSize = imageSize
 	return t


### PR DESCRIPTION
NOTE: for backward compatibility (and not breaking any client library who use this SDK), I choose to use WithImageOptions() and return the object itself.

2017/11/30 New options for template message images:

"We have released imageAspectRatio, imageSize, and imageBackgroundColor
fields for Buttons and Carousel template messages. Using these fields,
you can configure the aspect ratio, size, and background color for
images used in template messages."

Ref:
 - https://developers.line.me/en/docs/messaging-api/reference/#buttons
 - https://developers.line.me/en/docs/messaging-api/reference/#carousel