### PR TITLE
Make interface markers visible to other packages

### DIFF
--- a/linebot/imagemap.go
+++ b/linebot/imagemap.go
@@ -44,7 +44,7 @@ type ImagemapArea struct {
 // ImagemapAction type
 type ImagemapAction interface {
 	json.Marshaler
-	imagemapAction()
+	ImagemapAction()
 }
 
 // URIImagemapAction type
@@ -86,8 +86,8 @@ func (a *MessageImagemapAction) MarshalJSON() ([]byte, error) {
 }
 
 // implements ImagemapAction interface
-func (a *URIImagemapAction) imagemapAction()     {}
-func (a *MessageImagemapAction) imagemapAction() {}
+func (a *URIImagemapAction) ImagemapAction()     {}
+func (a *MessageImagemapAction) ImagemapAction() {}
 
 // NewURIImagemapAction function
 func NewURIImagemapAction(linkURL string, area ImagemapArea) *URIImagemapAction {

--- a/linebot/message.go
+++ b/linebot/message.go
@@ -36,7 +36,7 @@ const (
 // Message interface
 type Message interface {
 	json.Marshaler
-	message()
+	Message()
 }
 
 // TextMessage type
@@ -207,14 +207,14 @@ func (m *ImagemapMessage) MarshalJSON() ([]byte, error) {
 }
 
 // implements Message interface
-func (*TextMessage) message()     {}
-func (*ImageMessage) message()    {}
-func (*VideoMessage) message()    {}
-func (*AudioMessage) message()    {}
-func (*LocationMessage) message() {}
-func (*StickerMessage) message()  {}
-func (*TemplateMessage) message() {}
-func (*ImagemapMessage) message() {}
+func (*TextMessage) Message()     {}
+func (*ImageMessage) Message()    {}
+func (*VideoMessage) Message()    {}
+func (*AudioMessage) Message()    {}
+func (*LocationMessage) Message() {}
+func (*StickerMessage) Message()  {}
+func (*TemplateMessage) Message() {}
+func (*ImagemapMessage) Message() {}
 
 // NewTextMessage function
 func NewTextMessage(content string) *TextMessage {

--- a/linebot/template.go
+++ b/linebot/template.go
@@ -61,7 +61,7 @@ const (
 // Template interface
 type Template interface {
 	json.Marshaler
-	template()
+	Template()
 }
 
 // ButtonsTemplate type
@@ -192,10 +192,10 @@ func (t *ImageCarouselTemplate) MarshalJSON() ([]byte, error) {
 }
 
 // implements Template interface
-func (*ConfirmTemplate) template()       {}
-func (*ButtonsTemplate) template()       {}
-func (*CarouselTemplate) template()      {}
-func (*ImageCarouselTemplate) template() {}
+func (*ConfirmTemplate) Template()       {}
+func (*ButtonsTemplate) Template()       {}
+func (*CarouselTemplate) Template()      {}
+func (*ImageCarouselTemplate) Template() {}
 
 // NewConfirmTemplate function
 func NewConfirmTemplate(text string, left, right TemplateAction) *ConfirmTemplate {
@@ -252,7 +252,7 @@ func NewImageCarouselColumn(imageURL string, action TemplateAction) *ImageCarous
 // TemplateAction interface
 type TemplateAction interface {
 	json.Marshaler
-	templateAction()
+	TemplateAction()
 }
 
 // URITemplateAction type
@@ -350,10 +350,10 @@ func (a *DatetimePickerTemplateAction) MarshalJSON() ([]byte, error) {
 }
 
 // implements TemplateAction interface
-func (*URITemplateAction) templateAction()            {}
-func (*MessageTemplateAction) templateAction()        {}
-func (*PostbackTemplateAction) templateAction()       {}
-func (*DatetimePickerTemplateAction) templateAction() {}
+func (*URITemplateAction) TemplateAction()            {}
+func (*MessageTemplateAction) TemplateAction()        {}
+func (*PostbackTemplateAction) TemplateAction()       {}
+func (*DatetimePickerTemplateAction) TemplateAction() {}
 
 // NewURITemplateAction function
 func NewURITemplateAction(label, uri string) *URITemplateAction {


### PR DESCRIPTION
As discussed in #59 this would make the "marker" methods for the `ImagemapAction`, `Message`, `Template` and `TemplateAction` interfaces visible for consumers of this package, allowing them to implement them on their own (in case they just need to pass through data for example).