### PR TITLE
Fix not to ignore Hash.write error

### DIFF
--- a/linebot/webhook.go
+++ b/linebot/webhook.go
@@ -54,6 +54,11 @@ func validateSignature(channelSecret, signature string, body []byte) bool {
 		return false
 	}
 	hash := hmac.New(sha256.New, []byte(channelSecret))
-	hash.Write(body)
+
+	_, err = hash.Write(body)
+	if err != nil {
+		return false
+	}
+
 	return hmac.Equal(decoded, hash.Sum(nil))
 }


### PR DESCRIPTION
`hash.Write` could return error but currently it is ignored. I'm not pretty sure when `hash.Write` returns error, but I believe it is a good habit to make sure that `hash.Sum(nil)` calculate hash based on right value.

Thanks 👍 