### PR TITLE
Add member join/leave event

### DIFF
--- a/linebot/event.go
+++ b/linebot/event.go
@@ -30,6 +30,8 @@ const (
 	EventTypeUnfollow    EventType = "unfollow"
 	EventTypeJoin        EventType = "join"
 	EventTypeLeave       EventType = "leave"
+	EventTypeMemberJoin  EventType = "memberJoined"
+	EventTypeMemberLeave EventType = "memberLeft"
 	EventTypePostback    EventType = "postback"
 	EventTypeBeacon      EventType = "beacon"
 	EventTypeAccountLink EventType = "accountLink"
@@ -108,6 +110,7 @@ type Event struct {
 	Postback    *Postback
 	Beacon      *Beacon
 	AccountLink *AccountLink
+	Members     []*EventSource
 }
 
 type rawEvent struct {
@@ -119,6 +122,12 @@ type rawEvent struct {
 	*Postback   `json:"postback,omitempty"`
 	Beacon      *rawBeaconEvent      `json:"beacon,omitempty"`
 	AccountLink *rawAccountLinkEvent `json:"link,omitempty"`
+	Joined      *rawMemberEvent      `json:"joined,omitempty"`
+	Left        *rawMemberEvent      `json:"left,omitempty"`
+}
+
+type rawMemberEvent struct {
+	Members []*EventSource `json:"members"`
 }
 
 type rawEventMessage struct {
@@ -172,6 +181,17 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 		raw.AccountLink = &rawAccountLinkEvent{
 			Result: e.AccountLink.Result,
 			Nonce:  e.AccountLink.Nonce,
+		}
+	}
+
+	switch e.Type {
+	case EventTypeMemberJoin:
+		raw.Joined = &rawMemberEvent{
+			Members: e.Members,
+		}
+	case EventTypeMemberLeave:
+		raw.Left = &rawMemberEvent{
+			Members: e.Members,
 		}
 	}
 
@@ -290,6 +310,10 @@ func (e *Event) UnmarshalJSON(body []byte) (err error) {
 			Result: rawEvent.AccountLink.Result,
 			Nonce:  rawEvent.AccountLink.Nonce,
 		}
+	case EventTypeMemberJoin:
+		e.Members = rawEvent.Joined.Members
+	case EventTypeMemberLeave:
+		e.Members = rawEvent.Left.Members
 	}
 	return
 }

--- a/linebot/webhook_test.go
+++ b/linebot/webhook_test.go
@@ -249,6 +249,47 @@ var webhookTestRequestBody = `{
             "result": "ok",
             "nonce": "xxxxxxxxxxxxxxx"
           }
+        },
+        {
+          "replyToken": "0f3779fba3b349968c5d07db31eabf65",
+          "type": "memberJoined",
+          "timestamp": 1462629479859,
+          "source": {
+            "type": "group",
+            "groupId": "C4af498062901234567890123456789ab"
+          },
+          "joined": {
+            "members": [
+              {
+                "type": "user",
+                "userId": "U4af498062901234567890123456789ab"
+              },
+              {
+                "type": "user",
+                "userId": "U91eeaf62d901234567890123456789ab"
+              }
+            ]
+          }
+        },
+        {
+          "type": "memberLeft",
+          "timestamp": 1462629479960,
+          "source": {
+            "type": "group",
+            "groupId": "C4af498062901234567890123456789ab"
+          },
+          "left": {
+            "members": [
+              {
+                "type": "user",
+                "userId": "U4af498062901234567890123456789ab"
+              },
+              {
+                "type": "user",
+                "userId": "U91eeaf62d901234567890123456789ab"
+              }
+            ]
+          }
         }
     ]
 }
@@ -468,6 +509,43 @@ var webhookTestWantEvents = []*Event{
 		AccountLink: &AccountLink{
 			Result: AccountLinkResultOK,
 			Nonce:  "xxxxxxxxxxxxxxx",
+		},
+	},
+	{
+		ReplyToken: "0f3779fba3b349968c5d07db31eabf65",
+		Type:       EventTypeMemberJoin,
+		Timestamp:  time.Date(2016, time.May, 7, 13, 57, 59, int(859*time.Millisecond), time.UTC),
+		Source: &EventSource{
+			Type:    EventSourceTypeGroup,
+			GroupID: "C4af498062901234567890123456789ab",
+		},
+		Members: []*EventSource{
+			&EventSource{
+				Type:   EventSourceTypeUser,
+				UserID: "U4af498062901234567890123456789ab",
+			},
+			&EventSource{
+				Type:   EventSourceTypeUser,
+				UserID: "U91eeaf62d901234567890123456789ab",
+			},
+		},
+	},
+	{
+		Type:      EventTypeMemberLeave,
+		Timestamp: time.Date(2016, time.May, 7, 13, 57, 59, int(960*time.Millisecond), time.UTC),
+		Source: &EventSource{
+			Type:    EventSourceTypeGroup,
+			GroupID: "C4af498062901234567890123456789ab",
+		},
+		Members: []*EventSource{
+			&EventSource{
+				Type:   EventSourceTypeUser,
+				UserID: "U4af498062901234567890123456789ab",
+			},
+			&EventSource{
+				Type:   EventSourceTypeUser,
+				UserID: "U91eeaf62d901234567890123456789ab",
+			},
 		},
 	},
 }


### PR DESCRIPTION
Note: in the raw events of member join/leave, "left"/"leave" keys should
be avoid, since we can distinguish them via event type.