### PR TITLE
Fix/nil body checking

### DIFF
--- a/linebot/account_link.go
+++ b/linebot/account_link.go
@@ -46,11 +46,9 @@ func (call *IssueLinkTokenCall) WithContext(ctx context.Context) *IssueLinkToken
 func (call *IssueLinkTokenCall) Do() (*LinkTokenResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointLinkToken, call.userID)
 	res, err := call.c.post(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToLinkTokenResponse(res)
 }

--- a/linebot/client.go
+++ b/linebot/client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -178,4 +179,10 @@ func (client *Client) delete(ctx context.Context, endpoint string) (*http.Respon
 		return nil, err
 	}
 	return client.do(ctx, req)
+}
+
+func closeResponse(res *http.Response) error {
+	defer res.Body.Close()
+	_, err := io.Copy(ioutil.Discard, res.Body)
+	return err
 }

--- a/linebot/get_content.go
+++ b/linebot/get_content.go
@@ -48,5 +48,6 @@ func (call *GetMessageContentCall) Do() (*MessageContentResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToMessageContentResponse(res)
 }

--- a/linebot/get_ids.go
+++ b/linebot/get_ids.go
@@ -52,12 +52,10 @@ func (call *GetGroupMemberIDsCall) Do() (*MemberIDsResponse, error) {
 		q = url.Values{"start": []string{call.continuationToken}}
 	}
 	res, err := call.c.get(call.ctx, endpoint, q)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToMemberIDsResponse(res)
 }
 
@@ -93,12 +91,10 @@ func (call *GetRoomMemberIDsCall) Do() (*MemberIDsResponse, error) {
 		q = url.Values{"start": []string{call.continuationToken}}
 	}
 	res, err := call.c.get(call.ctx, endpoint, q)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToMemberIDsResponse(res)
 }
 

--- a/linebot/get_profile.go
+++ b/linebot/get_profile.go
@@ -45,12 +45,10 @@ func (call *GetProfileCall) WithContext(ctx context.Context) *GetProfileCall {
 func (call *GetProfileCall) Do() (*UserProfileResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointGetProfile, call.userID)
 	res, err := call.c.get(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToUserProfileResponse(res)
 }
 
@@ -82,12 +80,10 @@ func (call *GetGroupMemberProfileCall) WithContext(ctx context.Context) *GetGrou
 func (call *GetGroupMemberProfileCall) Do() (*UserProfileResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointGetGroupMemberProfile, call.groupID, call.userID)
 	res, err := call.c.get(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToUserProfileResponse(res)
 }
 
@@ -119,11 +115,9 @@ func (call *GetRoomMemberProfileCall) WithContext(ctx context.Context) *GetRoomM
 func (call *GetRoomMemberProfileCall) Do() (*UserProfileResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointGetRoomMemberProfile, call.roomID, call.userID)
 	res, err := call.c.get(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToUserProfileResponse(res)
 }

--- a/linebot/leave.go
+++ b/linebot/leave.go
@@ -45,12 +45,10 @@ func (call *LeaveGroupCall) WithContext(ctx context.Context) *LeaveGroupCall {
 func (call *LeaveGroupCall) Do() (*BasicResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointLeaveGroup, call.groupID)
 	res, err := call.c.post(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -80,11 +78,9 @@ func (call *LeaveRoomCall) WithContext(ctx context.Context) *LeaveRoomCall {
 func (call *LeaveRoomCall) Do() (*BasicResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointLeaveRoom, call.roomID)
 	res, err := call.c.post(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }

--- a/linebot/liff.go
+++ b/linebot/liff.go
@@ -71,12 +71,10 @@ func (call *GetLIFFAllCall) WithContext(ctx context.Context) *GetLIFFAllCall {
 // Do method
 func (call *GetLIFFAllCall) Do() (*LIFFAppsResponse, error) {
 	res, err := call.c.get(call.ctx, APIEndpointGetAllLIFFApps, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToLIFFResponse(res)
 }
 
@@ -118,12 +116,10 @@ func (call *AddLIFFCall) Do() (*LIFFIDResponse, error) {
 		return nil, err
 	}
 	res, err := call.c.post(call.ctx, APIEndpointAddLIFFApp, &buf)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToLIFFIDResponse(res)
 }
 
@@ -171,12 +167,10 @@ func (call *UpdateLIFFCall) Do() (*BasicResponse, error) {
 
 	endpoint := fmt.Sprintf(APIEndpointUpdateLIFFApp, call.liffID)
 	res, err := call.c.put(call.ctx, endpoint, &buf)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -206,11 +200,9 @@ func (call *DeleteLIFFCall) WithContext(ctx context.Context) *DeleteLIFFCall {
 func (call *DeleteLIFFCall) Do() (*BasicResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointDeleteLIFFApp, call.liffID)
 	res, err := call.c.delete(call.ctx, endpoint)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }

--- a/linebot/response.go
+++ b/linebot/response.go
@@ -15,8 +15,10 @@
 package linebot
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -146,8 +148,12 @@ func decodeToMessageContentResponse(res *http.Response) (*MessageContentResponse
 	if err := checkResponse(res); err != nil {
 		return nil, err
 	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, res.Body); err != nil {
+		return nil, err
+	}
 	result := MessageContentResponse{
-		Content:       res.Body,
+		Content:       ioutil.NopCloser(&buf),
 		ContentType:   res.Header.Get("Content-Type"),
 		ContentLength: res.ContentLength,
 	}

--- a/linebot/richmenu.go
+++ b/linebot/richmenu.go
@@ -131,12 +131,10 @@ func (call *GetRichMenuCall) WithContext(ctx context.Context) *GetRichMenuCall {
 func (call *GetRichMenuCall) Do() (*RichMenuResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointGetRichMenu, call.richMenuID)
 	res, err := call.c.get(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToRichMenuResponse(res)
 }
 
@@ -166,12 +164,10 @@ func (call *GetUserRichMenuCall) WithContext(ctx context.Context) *GetUserRichMe
 func (call *GetUserRichMenuCall) Do() (*RichMenuResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointGetUserRichMenu, call.userID)
 	res, err := call.c.get(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToRichMenuResponse(res)
 }
 
@@ -221,12 +217,10 @@ func (call *CreateRichMenuCall) Do() (*RichMenuIDResponse, error) {
 		return nil, err
 	}
 	res, err := call.c.post(call.ctx, APIEndpointCreateRichMenu, &buf)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToRichMenuIDResponse(res)
 }
 
@@ -256,12 +250,10 @@ func (call *DeleteRichMenuCall) WithContext(ctx context.Context) *DeleteRichMenu
 func (call *DeleteRichMenuCall) Do() (*BasicResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointDeleteRichMenu, call.richMenuID)
 	res, err := call.c.delete(call.ctx, endpoint)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -293,12 +285,10 @@ func (call *LinkUserRichMenuCall) WithContext(ctx context.Context) *LinkUserRich
 func (call *LinkUserRichMenuCall) Do() (*BasicResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointLinkUserRichMenu, call.userID, call.richMenuID)
 	res, err := call.c.post(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -328,12 +318,10 @@ func (call *UnlinkUserRichMenuCall) WithContext(ctx context.Context) *UnlinkUser
 func (call *UnlinkUserRichMenuCall) Do() (*BasicResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointUnlinkUserRichMenu, call.userID)
 	res, err := call.c.delete(call.ctx, endpoint)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -363,12 +351,10 @@ func (call *SetDefaultRichMenuCall) WithContext(ctx context.Context) *SetDefault
 func (call *SetDefaultRichMenuCall) Do() (*BasicResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointSetDefaultRichMenu, call.richMenuID)
 	res, err := call.c.post(call.ctx, endpoint, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -394,12 +380,10 @@ func (call *CancelDefaultRichMenuCall) WithContext(ctx context.Context) *CancelD
 // Do method
 func (call *CancelDefaultRichMenuCall) Do() (*BasicResponse, error) {
 	res, err := call.c.delete(call.ctx, APIEndpointDefaultRichMenu)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -425,12 +409,10 @@ func (call *GetDefaultRichMenuCall) WithContext(ctx context.Context) *GetDefault
 // Do method
 func (call *GetDefaultRichMenuCall) Do() (*RichMenuIDResponse, error) {
 	res, err := call.c.get(call.ctx, APIEndpointDefaultRichMenu, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToRichMenuIDResponse(res)
 }
 
@@ -456,12 +438,10 @@ func (call *GetRichMenuListCall) WithContext(ctx context.Context) *GetRichMenuLi
 // Do method
 func (call *GetRichMenuListCall) Do() ([]*RichMenuResponse, error) {
 	res, err := call.c.get(call.ctx, APIEndpointListRichMenu, nil)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToRichMenuListResponse(res)
 }
 
@@ -549,5 +529,6 @@ func (call *UploadRichMenuImageCall) Do() (*BasicResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }

--- a/linebot/richmenu.go
+++ b/linebot/richmenu.go
@@ -474,6 +474,7 @@ func (call *DownloadRichMenuImageCall) Do() (*MessageContentResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToMessageContentResponse(res)
 }
 

--- a/linebot/send_message.go
+++ b/linebot/send_message.go
@@ -63,12 +63,10 @@ func (call *PushMessageCall) Do() (*BasicResponse, error) {
 		return nil, err
 	}
 	res, err := call.c.post(call.ctx, APIEndpointPushMessage, &buf)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -114,12 +112,10 @@ func (call *ReplyMessageCall) Do() (*BasicResponse, error) {
 		return nil, err
 	}
 	res, err := call.c.post(call.ctx, APIEndpointReplyMessage, &buf)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }
 
@@ -165,11 +161,9 @@ func (call *MulticastCall) Do() (*BasicResponse, error) {
 		return nil, err
 	}
 	res, err := call.c.post(call.ctx, APIEndpointMulticast, &buf)
-	if res != nil && res.Body != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer closeResponse(res)
 	return decodeToBasicResponse(res)
 }


### PR DESCRIPTION
issue: #126 #127

* the http Client and Transport guarantee that Body is always non-nil
* the default http client's Transport may not reuse the connection if the Body is not read to completion
* Response.Body is not just ReadCloser, which is needed to read completely and closed