### PR TITLE
Fix: support marshalling message type "file"

### DIFF
--- a/linebot/event.go
+++ b/linebot/event.go
@@ -239,6 +239,13 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 			ID:       m.ID,
 			Duration: m.Duration,
 		}
+	case *FileMessage:
+		raw.Message = &rawEventMessage{
+			Type:     MessageTypeFile,
+			ID:       m.ID,
+			FileName: m.FileName,
+			FileSize: m.FileSize,
+		}
 	case *LocationMessage:
 		raw.Message = &rawEventMessage{
 			Type:      MessageTypeLocation,


### PR DESCRIPTION
### Reproduce steps:

1) `MarshalJSON` with a message type "file". `raw.Message` will be missing
2) `UnmarshalJSON` from the array of bytes from the previous operation
3) `runtime error: invalid memory address or nil pointer dereference` will be occurs

