### PR TITLE
Add URIAction.AltURI.Desktop

### DIFF
--- a/examples/kitchensink/server.go
+++ b/examples/kitchensink/server.go
@@ -518,7 +518,10 @@ func (app *KitchenSink) handleText(message *linebot.TextMessage, replyToken stri
         "action": {
           "type": "uri",
           "label": "WEBSITE",
-          "uri": "https://linecorp.com"
+          "uri": "https://linecorp.com",
+          "altUri": {
+            "desktop": "https://line.me/ja/download"
+          }
         }
       },
       {

--- a/linebot/actions.go
+++ b/linebot/actions.go
@@ -49,20 +49,28 @@ type QuickReplyAction interface {
 
 // URIAction type
 type URIAction struct {
-	Label string
-	URI   string
+	Label  string
+	URI    string
+	AltURI *URIActionAltURI
+}
+
+// URIActionAltURI type
+type URIActionAltURI struct {
+	Desktop string `json:"desktop"`
 }
 
 // MarshalJSON method of URIAction
 func (a *URIAction) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type  ActionType `json:"type"`
-		Label string     `json:"label,omitempty"`
-		URI   string     `json:"uri"`
+		Type   ActionType       `json:"type"`
+		Label  string           `json:"label,omitempty"`
+		URI    string           `json:"uri"`
+		AltURI *URIActionAltURI `json:"altUri,omitempty"`
 	}{
-		Type:  ActionTypeURI,
-		Label: a.Label,
-		URI:   a.URI,
+		Type:   ActionTypeURI,
+		Label:  a.Label,
+		URI:    a.URI,
+		AltURI: a.AltURI,
 	})
 }
 

--- a/linebot/flex_test.go
+++ b/linebot/flex_test.go
@@ -264,7 +264,10 @@ func TestUnmarshalFlexMessageJSON(t *testing.T) {
         "action": {
           "type": "uri",
           "label": "WEBSITE",
-          "uri": "https://linecorp.com"
+          "uri": "https://linecorp.com",
+          "altUri": {
+            "desktop": "https://line.me/ja/download"
+          }
         }
       },
       {
@@ -414,6 +417,9 @@ func TestUnmarshalFlexMessageJSON(t *testing.T) {
 							Action: &URIAction{
 								Label: "WEBSITE",
 								URI:   "https://linecorp.com",
+								AltURI: &URIActionAltURI{
+									Desktop: "https://line.me/ja/download",
+								},
 							},
 							Height: FlexButtonHeightTypeSm,
 							Style:  FlexButtonStyleTypeLink,


### PR DESCRIPTION
Resolve #143.

- Added `URIAction.AltURI` as optional property.
- Added tests to `flex_test.go` (because `altUri` property is supported only in Flex Messages).
- Update `kitchensink` server
  - When the user says "flex json" command, the bot replies flex message with two buttons. When opened in the desktop version, the second link will open a different URI than the mobile version.