### PR TITLE
update issues template to apply multiple issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,10 @@
+---
+title: 'Bug Report'
+labels: but
+assignees: k2wanko
+---
+
+<!--
 ## Do this before creating an issue
 
 - Check our [developer documentation](https://developers.line.me/en/docs/) and [FAQ](https://developers.line.me/en/faq/messaging-api/) page for more information on LINE bots and the Messaging API
@@ -5,5 +12,27 @@
 
 ## When creating an issue
 
-- Provide detailed information about the issue you had with the SDK
+- Provide detailed information about the issue you had with the SDK as below
 - Provide logs if possible
+-->
+
+## System Informations
+
+* Go version:
+* OS:
+
+## Expected Behavior
+<!-- Tell us what should happen -->
+
+## Current Behavior
+<!-- Tell us what happens instead of the expected behavior -->
+
+## Steps to Reproduce
+<!-- Provide a link to a live example, or an unambigeous set of steps to -->
+1.
+1.
+1.
+1.
+
+## Logs
+<!-- Provide logs if possible -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ assignees: k2wanko
 ## Do this before creating an issue
 
 - Check our [developer documentation](https://developers.line.me/en/docs/) and [FAQ](https://developers.line.me/en/faq/messaging-api/) page for more information on LINE bots and the Messaging API
-- Make sure your issue is **related to** the LINE Bot SDK. For general questions or issues about LINE bots, create an issue on the [LINE Platform feedback](https://github.com/line/line-platform-feedback) repository. Note that we don't provide technical support.
 
 ## When creating an issue
 


### PR DESCRIPTION
GitHub is now supporting multiple issues with ISSUE_TEMPLATE **directory**.
I write a new issue template for bug report with commented old one, and put it into new ISSUE_TEMPLATE directory.
We can add some more types of issue templates, however first of all I start with bug report.
