### PR TITLE
Fixed declaration of FlexContainerType

### DIFF
--- a/linebot/flex.go
+++ b/linebot/flex.go
@@ -17,7 +17,7 @@ package linebot
 import "encoding/json"
 
 // FlexContainerType type
-type FlexContainerType = string // alias type
+type FlexContainerType string // alias type
 
 // IntPtr is a helper function for using *int values
 func IntPtr(v int) *int {

--- a/linebot/flex.go
+++ b/linebot/flex.go
@@ -17,7 +17,7 @@ package linebot
 import "encoding/json"
 
 // FlexContainerType type
-type FlexContainerType string // alias type
+type FlexContainerType string
 
 // IntPtr is a helper function for using *int values
 func IntPtr(v int) *int {

--- a/linebot/flex.go
+++ b/linebot/flex.go
@@ -19,7 +19,6 @@ import "encoding/json"
 // FlexContainerType type
 type FlexContainerType string
 
-
 // IntPtr is a helper function for using *int values
 func IntPtr(v int) *int {
 	return &v

--- a/linebot/flex.go
+++ b/linebot/flex.go
@@ -19,6 +19,7 @@ import "encoding/json"
 // FlexContainerType type
 type FlexContainerType string
 
+
 // IntPtr is a helper function for using *int values
 func IntPtr(v int) *int {
 	return &v


### PR DESCRIPTION
type FlexContainerType = string // alias type

Removed "=" in this declaration.

If this "=" is present, the linebot definition hover message will not be displayed in VSC on Mac OS.

Example
test.go code.

func testProc () {
var x linebot.TemplateAction
x.TemplateAction ()
_ = linebot.Client {}
_ = linebot.TextMessage {}
}

At this time, even if the mouse cursor is hovered over TemplateAction, Client, TextMessage, etc., the hint message is not displayed.

type FlexContainerType = string // alias type

This "=" is grammatical, but the VSC Go plugin doesn't seem to interpret correctly.