### PR TITLE
add field `stickerResourceType` to sicker message

### DIFF
--- a/examples/echo_bot/server.go
+++ b/examples/echo_bot/server.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -47,6 +48,12 @@ func main() {
 				switch message := event.Message.(type) {
 				case *linebot.TextMessage:
 					if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(message.Text)).Do(); err != nil {
+						log.Print(err)
+					}
+				case *linebot.StickerMessage:
+					replyMessage := fmt.Sprintf(
+						"sticker id is %s, stickerResourceType is %s", message.StickerID, message.StickerResourceType)
+					if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(replyMessage)).Do(); err != nil {
 						log.Print(err)
 					}
 				}

--- a/linebot/event.go
+++ b/linebot/event.go
@@ -150,6 +150,20 @@ type Things struct {
 	Result   *ThingsResult
 }
 
+// StickerResourceType type
+type StickerResourceType string
+
+// StickerResourceType constants
+const (
+	StickerResourceTypeStatic         StickerResourceType = "STATIC"
+	StickerResourceTypeAnimation      StickerResourceType = "ANIMATION"
+	StickerResourceTypeSound          StickerResourceType = "SOUND"
+	StickerResourceTypeAnimationSound StickerResourceType = "ANIMATION_SOUND"
+	StickerResourceTypePopup          StickerResourceType = "POPUP"
+	StickerResourceTypePopupSound     StickerResourceType = "POPUP_SOUND"
+	StickerResourceTypeNameText       StickerResourceType = "NAME_TEXT"
+)
+
 // Event type
 type Event struct {
 	ReplyToken  string
@@ -185,18 +199,19 @@ type rawMemberEvent struct {
 }
 
 type rawEventMessage struct {
-	ID        string      `json:"id"`
-	Type      MessageType `json:"type"`
-	Text      string      `json:"text,omitempty"`
-	Duration  int         `json:"duration,omitempty"`
-	Title     string      `json:"title,omitempty"`
-	Address   string      `json:"address,omitempty"`
-	FileName  string      `json:"fileName,omitempty"`
-	FileSize  int         `json:"fileSize,omitempty"`
-	Latitude  float64     `json:"latitude,omitempty"`
-	Longitude float64     `json:"longitude,omitempty"`
-	PackageID string      `json:"packageId,omitempty"`
-	StickerID string      `json:"stickerId,omitempty"`
+	ID                  string              `json:"id"`
+	Type                MessageType         `json:"type"`
+	Text                string              `json:"text,omitempty"`
+	Duration            int                 `json:"duration,omitempty"`
+	Title               string              `json:"title,omitempty"`
+	Address             string              `json:"address,omitempty"`
+	FileName            string              `json:"fileName,omitempty"`
+	FileSize            int                 `json:"fileSize,omitempty"`
+	Latitude            float64             `json:"latitude,omitempty"`
+	Longitude           float64             `json:"longitude,omitempty"`
+	PackageID           string              `json:"packageId,omitempty"`
+	StickerID           string              `json:"stickerId,omitempty"`
+	StickerResourceType StickerResourceType `json:"stickerResourceType,omitempty"`
 }
 
 type rawBeaconEvent struct {
@@ -338,10 +353,11 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 		}
 	case *StickerMessage:
 		raw.Message = &rawEventMessage{
-			Type:      MessageTypeSticker,
-			ID:        m.ID,
-			PackageID: m.PackageID,
-			StickerID: m.StickerID,
+			Type:                MessageTypeSticker,
+			ID:                  m.ID,
+			PackageID:           m.PackageID,
+			StickerID:           m.StickerID,
+			StickerResourceType: m.StickerResourceType,
 		}
 	}
 	return json.Marshal(&raw)
@@ -396,9 +412,10 @@ func (e *Event) UnmarshalJSON(body []byte) (err error) {
 			}
 		case MessageTypeSticker:
 			e.Message = &StickerMessage{
-				ID:        rawEvent.Message.ID,
-				PackageID: rawEvent.Message.PackageID,
-				StickerID: rawEvent.Message.StickerID,
+				ID:                  rawEvent.Message.ID,
+				PackageID:           rawEvent.Message.PackageID,
+				StickerID:           rawEvent.Message.StickerID,
+				StickerResourceType: rawEvent.Message.StickerResourceType,
 			}
 		}
 	case EventTypePostback:

--- a/linebot/message.go
+++ b/linebot/message.go
@@ -208,9 +208,10 @@ func (m *LocationMessage) WithQuickReplies(items *QuickReplyItems) SendingMessag
 
 // StickerMessage type
 type StickerMessage struct {
-	ID        string
-	PackageID string
-	StickerID string
+	ID                  string
+	PackageID           string
+	StickerID           string
+	StickerResourceType StickerResourceType
 
 	quickReplyitems *QuickReplyItems
 }
@@ -218,15 +219,17 @@ type StickerMessage struct {
 // MarshalJSON method of StickerMessage
 func (m *StickerMessage) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type       MessageType      `json:"type"`
-		PackageID  string           `json:"packageId"`
-		StickerID  string           `json:"stickerId"`
-		QuickReply *QuickReplyItems `json:"quickReply,omitempty"`
+		Type                MessageType         `json:"type"`
+		PackageID           string              `json:"packageId"`
+		StickerID           string              `json:"stickerId"`
+		StickerResourceType StickerResourceType `json:"stickerResourceType,omitempty"`
+		QuickReply          *QuickReplyItems    `json:"quickReply,omitempty"`
 	}{
-		Type:       MessageTypeSticker,
-		PackageID:  m.PackageID,
-		StickerID:  m.StickerID,
-		QuickReply: m.quickReplyitems,
+		Type:                MessageTypeSticker,
+		PackageID:           m.PackageID,
+		StickerID:           m.StickerID,
+		StickerResourceType: m.StickerResourceType,
+		QuickReply:          m.quickReplyitems,
 	})
 }
 

--- a/linebot/webhook_test.go
+++ b/linebot/webhook_test.go
@@ -117,7 +117,24 @@ var webhookTestRequestBody = `{
                 "id": "325708",
                 "type": "sticker",
                 "packageId": "1",
-                "stickerId": "1"
+                "stickerId": "1",
+                "stickerResourceType": "STATIC"
+            }
+        },
+        {
+            "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+            "type": "message",
+            "timestamp": 1462629479859,
+            "source": {
+                "type": "user",
+                "userId": "u206d25c2ea6bd87c17655609a1c37cb8"
+            },
+            "message": {
+                "id": "325708",
+                "type": "sticker",
+                "packageId": "1",
+                "stickerId": "3",
+                "stickerResourceType": "ANIMATION_SOUND"
             }
         },
         {
@@ -449,9 +466,25 @@ var webhookTestWantEvents = []*Event{
 			UserID: "u206d25c2ea6bd87c17655609a1c37cb8",
 		},
 		Message: &StickerMessage{
-			ID:        "325708",
-			PackageID: "1",
-			StickerID: "1",
+			ID:                  "325708",
+			PackageID:           "1",
+			StickerID:           "1",
+			StickerResourceType: StickerResourceTypeStatic,
+		},
+	},
+	{
+		ReplyToken: "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+		Type:       EventTypeMessage,
+		Timestamp:  time.Date(2016, time.May, 7, 13, 57, 59, int(859*time.Millisecond), time.UTC),
+		Source: &EventSource{
+			Type:   EventSourceTypeUser,
+			UserID: "u206d25c2ea6bd87c17655609a1c37cb8",
+		},
+		Message: &StickerMessage{
+			ID:                  "325708",
+			PackageID:           "1",
+			StickerID:           "3",
+			StickerResourceType: StickerResourceTypeAnimationSound,
 		},
 	},
 	{


### PR DESCRIPTION
- New property added to "sticker message" webhook event
- example added in examples/echo_bot

Ref: https://developers.line.biz/en/reference/messaging-api/#wh-sticker