### PR TITLE
Add API to get user interaction statistics

### DIFF
--- a/linebot/insight.go
+++ b/linebot/insight.go
@@ -25,9 +25,10 @@ type InsightType string
 
 // InsightType constants
 const (
-	InsightTypeMessageDelivery InsightType = "message/delivery"
-	InsightTypeFollowers       InsightType = "followers"
-	InsightTypeDemographic     InsightType = "demographic"
+	InsightTypeMessageDelivery      InsightType = "message/delivery"
+	InsightTypeUserInteractionStats InsightType = "message/event"
+	InsightTypeFollowers            InsightType = "followers"
+	InsightTypeDemographic          InsightType = "demographic"
 )
 
 // GetNumberMessagesDeliveryCall type
@@ -141,4 +142,43 @@ func (call *GetFriendDemographicsCall) Do() (*MessagesFriendDemographicsResponse
 	}
 	defer closeResponse(res)
 	return decodeToMessagesFriendDemographicsResponse(res)
+}
+
+// GetUserInteractionStatsCall type
+type GetUserInteractionStatsCall struct {
+	c   *Client
+	ctx context.Context
+
+	requestId   string
+	insightType InsightType
+}
+
+// etUserInteractionStats method
+func (client *Client) GetUserInteractionStats(requestId string) *GetUserInteractionStatsCall {
+	return &GetUserInteractionStatsCall{
+		c:           client,
+		requestId:   requestId,
+		insightType: InsightTypeUserInteractionStats,
+	}
+}
+
+// WithContext method
+func (call *GetUserInteractionStatsCall) WithContext(ctx context.Context) *GetUserInteractionStatsCall {
+	call.ctx = ctx
+	return call
+}
+
+// Do method
+func (call *GetUserInteractionStatsCall) Do() (*MessagesUserInteractionStatsResponse, error) {
+	endpoint := fmt.Sprintf(APIEndpointInsight, call.insightType)
+	q := url.Values{}
+	if call.requestId != "" {
+		q.Add("requestId", call.requestId)
+	}
+	res, err := call.c.get(call.ctx, call.c.endpointBase, endpoint, q)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(res)
+	return decodeToMessagesUserInteractionStatsResponse(res)
 }

--- a/linebot/insight.go
+++ b/linebot/insight.go
@@ -149,15 +149,15 @@ type GetUserInteractionStatsCall struct {
 	c   *Client
 	ctx context.Context
 
-	requestId   string
+	requestID   string
 	insightType InsightType
 }
 
-// etUserInteractionStats method
-func (client *Client) GetUserInteractionStats(requestId string) *GetUserInteractionStatsCall {
+// GetUserInteractionStats method
+func (client *Client) GetUserInteractionStats(requestID string) *GetUserInteractionStatsCall {
 	return &GetUserInteractionStatsCall{
 		c:           client,
-		requestId:   requestId,
+		requestID:   requestID,
 		insightType: InsightTypeUserInteractionStats,
 	}
 }
@@ -172,8 +172,8 @@ func (call *GetUserInteractionStatsCall) WithContext(ctx context.Context) *GetUs
 func (call *GetUserInteractionStatsCall) Do() (*MessagesUserInteractionStatsResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointInsight, call.insightType)
 	q := url.Values{}
-	if call.requestId != "" {
-		q.Add("requestId", call.requestId)
+	if call.requestID != "" {
+		q.Add("requestId", call.requestID)
 	}
 	res, err := call.c.get(call.ctx, call.c.endpointBase, endpoint, q)
 	if err != nil {

--- a/linebot/insight.go
+++ b/linebot/insight.go
@@ -168,7 +168,7 @@ func (call *GetUserInteractionStatsCall) WithContext(ctx context.Context) *GetUs
 	return call
 }
 
-// Do method
+// Do method, returns MessagesUserInteractionStatsResponse
 func (call *GetUserInteractionStatsCall) Do() (*MessagesUserInteractionStatsResponse, error) {
 	endpoint := fmt.Sprintf(APIEndpointInsight, call.insightType)
 	q := url.Values{}

--- a/linebot/insight_test.go
+++ b/linebot/insight_test.go
@@ -578,14 +578,14 @@ func TestGetUserInteractionStats(t *testing.T) {
 	}
 	var testCases = []struct {
 		Label        string
-		RequestId    string
+		RequestID    string
 		ResponseCode int
 		Response     []byte
 		Want         want
 	}{
 		{
 			Label:        "Success",
-			RequestId:    "f70dd685-499a-4231-a441-f24b8d4fba21",
+			RequestID:    "f70dd685-499a-4231-a441-f24b8d4fba21",
 			ResponseCode: 200,
 			Response: []byte(`{
 				"overview": {
@@ -635,7 +635,7 @@ func TestGetUserInteractionStats(t *testing.T) {
 				RequestBody: []byte(""),
 				Response: &MessagesUserInteractionStatsResponse{
 					Overview: OverviewDetail{
-						RequestId:                   "f70dd685-499a-4231-a441-f24b8d4fba21",
+						RequestID:                   "f70dd685-499a-4231-a441-f24b8d4fba21",
 						Timestamp:                   1568214000,
 						Delivered:                   32,
 						UniqueImpression:            4,
@@ -729,7 +729,7 @@ func TestGetUserInteractionStats(t *testing.T) {
 	for i, tc := range testCases {
 		currentTestIdx = i
 		t.Run(strconv.Itoa(i)+"/"+tc.Label, func(t *testing.T) {
-			res, err := client.GetUserInteractionStats(tc.RequestId).Do()
+			res, err := client.GetUserInteractionStats(tc.RequestID).Do()
 			if tc.Want.Error != nil {
 				if !reflect.DeepEqual(err, tc.Want.Error) {
 					t.Errorf("Error %v; want %v", err, tc.Want.Error)

--- a/linebot/response.go
+++ b/linebot/response.go
@@ -148,7 +148,7 @@ type MessagesUserInteractionStatsResponse struct {
 
 // OverviewDetail type
 type OverviewDetail struct {
-	RequestId                   string `json:"requestId"`
+	RequestID                   string `json:"requestId"`
 	Timestamp                   int64  `json:"timestamp"`
 	Delivered                   int64  `json:"delivered"`
 	UniqueImpression            int64  `json:"uniqueImpression"`

--- a/linebot/response.go
+++ b/linebot/response.go
@@ -87,6 +87,7 @@ type MessagesNumberDeliveryResponse struct {
 	APIBroadcast    int64  `json:"apiBroadcast"`
 	APIPush         int64  `json:"apiPush"`
 	APIMulticast    int64  `json:"apiMulticast"`
+	APINarrowcast   int64  `json:"apiNarrowcast"`
 	APIReply        int64  `json:"apiReply"`
 }
 
@@ -103,7 +104,7 @@ type MessagesFriendDemographicsResponse struct {
 	Available           bool                       `json:"available"`
 	Genders             []GenderDetail             `json:"genders"`
 	Ages                []AgeDetail                `json:"ages"`
-	Areas               []AreasDetail          `json:"areas"`
+	Areas               []AreasDetail              `json:"areas"`
 	AppTypes            []AppTypeDetail            `json:"appTypes"`
 	SubscriptionPeriods []SubscriptionPeriodDetail `json:"subscriptionPeriods"`
 }
@@ -136,6 +137,49 @@ type AppTypeDetail struct {
 type SubscriptionPeriodDetail struct {
 	SubscriptionPeriod string  `json:"subscriptionPeriod"`
 	Percentage         float64 `json:"percentage"`
+}
+
+// MessagesUserInteractionStatsResponse type
+type MessagesUserInteractionStatsResponse struct {
+	Overview OverviewDetail  `json:"overview"`
+	Messages []MessageDetail `json:"messages"`
+	Clicks   []ClickDetail   `json:"clicks"`
+}
+
+// OverviewDetail type
+type OverviewDetail struct {
+	RequestId                   string `json:"requestId"`
+	Timestamp                   int64  `json:"timestamp"`
+	Delivered                   int64  `json:"delivered"`
+	UniqueImpression            int64  `json:"uniqueImpression"`
+	UniqueClick                 int64  `json:"uniqueClick"`
+	UniqueMediaPlayed           int64  `json:"uniqueMediaPlayed"`
+	UniqueMediaPlayed100Percent int64  `json:"uniqueMediaPlayed100Percent"`
+}
+
+// MessageDetail type
+type MessageDetail struct {
+	Seq                         int64 `json:"seq"`
+	Impression                  int64 `json:"impression"`
+	MediaPlayed                 int64 `json:"mediaPlayed"`
+	MediaPlayed25Percent        int64 `json:"mediaPlayed25Percent"`
+	MediaPlayed50Percent        int64 `json:"mediaPlayed50Percent"`
+	MediaPlayed75Percent        int64 `json:"mediaPlayed75Percent"`
+	MediaPlayed100Percent       int64 `json:"mediaPlayed100Percent"`
+	UniqueMediaPlayed           int64 `json:"uniqueMediaPlayed"`
+	UniqueMediaPlayed25Percent  int64 `json:"uniqueMediaPlayed25Percent"`
+	UniqueMediaPlayed50Percent  int64 `json:"uniqueMediaPlayed50Percent"`
+	UniqueMediaPlayed75Percent  int64 `json:"uniqueMediaPlayed75Percent"`
+	UniqueMediaPlayed100Percent int64 `json:"uniqueMediaPlayed100Percent"`
+}
+
+// ClickDetail type
+type ClickDetail struct {
+	Seq                  int64  `json:"seq"`
+	URL                  string `json:"url"`
+	Click                int64  `json:"click"`
+	UniqueClick          int64  `json:"uniqueClick"`
+	UniqueClickOfRequest int64  `json:"uniqueClickOfRequest"`
 }
 
 // RichMenuIDResponse type
@@ -393,6 +437,18 @@ func decodeToMessagesFriendDemographicsResponse(res *http.Response) (*MessagesFr
 	}
 	decoder := json.NewDecoder(res.Body)
 	result := MessagesFriendDemographicsResponse{}
+	if err := decoder.Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func decodeToMessagesUserInteractionStatsResponse(res *http.Response) (*MessagesUserInteractionStatsResponse, error) {
+	if err := checkResponse(res); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(res.Body)
+	result := MessagesUserInteractionStatsResponse{}
 	if err := decoder.Decode(&result); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- implements #177
- also add `apiNarrowcast` in message deliveries response

Ref: https://developers.line.biz/en/reference/messaging-api/#get-message-event