### PR TITLE
Support "Get narrowcast message status API"

### DIFF
--- a/linebot/client.go
+++ b/linebot/client.go
@@ -67,6 +67,7 @@ const (
 	APIEndpointLinkToken = "/v2/bot/user/%s/linkToken"
 
 	APIEndpointGetMessageDelivery = "/v2/bot/message/delivery/%s"
+	APIEndpointGetMessageProgress = "/v2/bot/message/progress/%s"
 	APIEndpointInsight            = "/v2/bot/insight/%s"
 
 	APIEndpointIssueAccessToken  = "/v2/oauth/accessToken"

--- a/linebot/progress.go
+++ b/linebot/progress.go
@@ -1,0 +1,68 @@
+// Copyright 2020 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package linebot
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// ProgressType type
+type ProgressType string
+
+// ProgressType constants
+const (
+	ProgressTypeNarrowcast ProgressType = "narrowcast"
+)
+
+// GetProgressNarrowcastMessages method
+func (client *Client) GetProgressNarrowcastMessages(requestID string) *GetProgressMessagesCall {
+	return &GetProgressMessagesCall{
+		c:            client,
+		requestID:    requestID,
+		progressType: ProgressTypeNarrowcast,
+	}
+}
+
+// GetProgressMessagesCall type
+type GetProgressMessagesCall struct {
+	c   *Client
+	ctx context.Context
+
+	requestID    string
+	progressType ProgressType
+}
+
+// WithContext method
+func (call *GetProgressMessagesCall) WithContext(ctx context.Context) *GetProgressMessagesCall {
+	call.ctx = ctx
+	return call
+}
+
+// Do method
+func (call *GetProgressMessagesCall) Do() (*MessagesProgressResponse, error) {
+	endpoint := fmt.Sprintf(APIEndpointGetMessageProgress, call.progressType)
+	var q url.Values
+	if call.requestID != "" {
+		q = url.Values{"requestId": []string{call.requestID}}
+	}
+	res, err := call.c.get(call.ctx, call.c.endpointBase, endpoint, q)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(res)
+	return decodeToMessagesProgressResponse(res)
+}

--- a/linebot/progress_test.go
+++ b/linebot/progress_test.go
@@ -90,6 +90,18 @@ func TestGetProgressMessages(t *testing.T) {
 				},
 			},
 		},
+		{
+			RequestID:    "f70dd685-499a-4",
+			TestType:     ProgressTypeNarrowcast,
+			ResponseCode: 404,
+			Response:     []byte(`invalid request ID`),
+			Want: want{
+				URLPath: fmt.Sprintf(APIEndpointGetMessageProgress, ProgressTypeNarrowcast),
+				Error: &APIError{
+					Code: 404,
+				},
+			},
+		},
 	}
 
 	var currentTestIdx int

--- a/linebot/progress_test.go
+++ b/linebot/progress_test.go
@@ -1,0 +1,150 @@
+// Copyright 2020 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package linebot
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// TestGetProgressMessages tests GetProgressNarrowcastMessages func
+func TestGetProgressMessages(t *testing.T) {
+	type want struct {
+		URLPath     string
+		RequestBody []byte
+		Response    *MessagesProgressResponse
+		Error       error
+	}
+	var testCases = []struct {
+		TestType     ProgressType
+		RequestID    string
+		ResponseCode int
+		Response     []byte
+		Want         want
+	}{
+		{
+			RequestID:    "f70dd685-499a-1",
+			TestType:     ProgressTypeNarrowcast,
+			ResponseCode: 200,
+			Response:     []byte(`{"phase":"waiting"}`),
+			Want: want{
+				URLPath: fmt.Sprintf(APIEndpointGetMessageProgress, ProgressTypeNarrowcast),
+				Response: &MessagesProgressResponse{
+					Phase:             "waiting",
+					SuccessCount:      0,
+					FailureCount:      0,
+					TargetCount:       0,
+					FailedDescription: "",
+					ErrorCode:         0,
+				},
+			},
+		},
+		{
+			RequestID:    "f70dd685-499a-2",
+			TestType:     ProgressTypeNarrowcast,
+			ResponseCode: 200,
+			Response:     []byte(`{"phase":"succeeded","successCount":10,"failureCount":0,"targetCount":10}`),
+			Want: want{
+				URLPath: fmt.Sprintf(APIEndpointGetMessageProgress, ProgressTypeNarrowcast),
+				Response: &MessagesProgressResponse{
+					Phase:             "succeeded",
+					SuccessCount:      10,
+					FailureCount:      0,
+					TargetCount:       10,
+					FailedDescription: "",
+					ErrorCode:         0,
+				},
+			},
+		},
+		{
+			RequestID:    "f70dd685-499a-3",
+			TestType:     ProgressTypeNarrowcast,
+			ResponseCode: 200,
+			Response:     []byte(`{"phase":"failed","failedDescription":"internal error","errorCode":1}`),
+			Want: want{
+				URLPath: fmt.Sprintf(APIEndpointGetMessageProgress, ProgressTypeNarrowcast),
+				Response: &MessagesProgressResponse{
+					Phase:             "failed",
+					SuccessCount:      0,
+					FailureCount:      0,
+					TargetCount:       0,
+					FailedDescription: "internal error",
+					ErrorCode:         1,
+				},
+			},
+		},
+	}
+
+	var currentTestIdx int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		tc := testCases[currentTestIdx]
+		if r.Method != http.MethodGet {
+			t.Errorf("Method %s; want %s", r.Method, http.MethodGet)
+		}
+		if r.URL.Path != tc.Want.URLPath {
+			t.Errorf("URLPath %s; want %s", r.URL.Path, tc.Want.URLPath)
+		}
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.WriteHeader(tc.ResponseCode)
+		w.Write(tc.Response)
+	}))
+	defer server.Close()
+
+	dataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		t.Error("Unexpected data API call")
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"Not found"}`))
+	}))
+	defer dataServer.Close()
+
+	client, err := mockClient(server, dataServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res interface{}
+	for i, tc := range testCases {
+		currentTestIdx = i
+		t.Run(strconv.Itoa(i)+"/"+string(tc.TestType)+"."+tc.RequestID, func(t *testing.T) {
+			switch tc.TestType {
+			case ProgressTypeNarrowcast:
+				res, err = client.GetProgressNarrowcastMessages(tc.RequestID).Do()
+			}
+			if tc.Want.Error != nil {
+				if !reflect.DeepEqual(err, tc.Want.Error) {
+					t.Errorf("Error %v; want %v", err, tc.Want.Error)
+				}
+			} else {
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			if tc.Want.Response != nil {
+				if !reflect.DeepEqual(res, tc.Want.Response) {
+					t.Errorf("Response %v; want %v", res, tc.Want.Response)
+				}
+			}
+		})
+	}
+}

--- a/linebot/response.go
+++ b/linebot/response.go
@@ -100,6 +100,16 @@ type MessagesNumberFollowersResponse struct {
 	Blocks          int64  `json:"blocks"`
 }
 
+// MessagesProgressResponse type
+type MessagesProgressResponse struct {
+	Phase             string `json:"phase"`
+	SuccessCount      int64  `json:"successCount"`
+	FailureCount      int64  `json:"failureCount"`
+	TargetCount       int64  `json:"targetCount"`
+	FailedDescription string `json:"failedDescription"`
+	ErrorCode         int    `json:"errorCode"`
+}
+
 // MessagesFriendDemographicsResponse type
 type MessagesFriendDemographicsResponse struct {
 	Available           bool                       `json:"available"`
@@ -452,6 +462,18 @@ func decodeToMessagesUserInteractionStatsResponse(res *http.Response) (*Messages
 	}
 	decoder := json.NewDecoder(res.Body)
 	result := MessagesUserInteractionStatsResponse{}
+	if err := decoder.Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func decodeToMessagesProgressResponse(res *http.Response) (*MessagesProgressResponse, error) {
+	if err := checkResponse(res); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(res.Body)
+	result := MessagesProgressResponse{}
 	if err := decoder.Decode(&result); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- follow #190, #191, implements the following API:
  https://developers.line.biz/en/reference/messaging-api/#get-narrowcast-progress-status
- use `ProgressType` for future use, i.e. we need to get other cast's progress.