### PR TITLE
Fix emoji: Fix test error by remove "omit empty" on index

### DIFF
--- a/linebot/emoji.go
+++ b/linebot/emoji.go
@@ -16,7 +16,7 @@ package linebot
 
 // Emoji type
 type Emoji struct {
-	Index     int    `json:"index,omitempty"`
+	Index     int    `json:"index"`
 	ProductID string `json:"productId,omitempty"`
 	EmojiID   string `json:"emojiId,omitempty"`
 }

--- a/linebot/send_message_test.go
+++ b/linebot/send_message_test.go
@@ -1407,7 +1407,7 @@ func TestBroadcastMessages(t *testing.T) {
 			ResponseCode: 200,
 			Response:     []byte(`{}`),
 			Want: want{
-				RequestBody: []byte(`{"messages":[{"type":"text","text":"Look at this: $ It's a LINE emoji!","emojis":[{"index":0,"productId":"5ac1bfd5040ab15980c9b435","emojiId":"086"},{"index":14,"productId":"5ac1bfd5040ab15980c9b435","emojiId":"001"}]}]}` + "\n"),
+				RequestBody: []byte(`{"messages":[{"type":"text","text":"$ Look at this: $ It's a LINE emoji!","emojis":[{"index":0,"productId":"5ac1bfd5040ab15980c9b435","emojiId":"086"},{"index":14,"productId":"5ac1bfd5040ab15980c9b435","emojiId":"001"}]}]}` + "\n"),
 				Response:    &BasicResponse{},
 			},
 		},

--- a/linebot/send_message_test.go
+++ b/linebot/send_message_test.go
@@ -1399,14 +1399,15 @@ func TestBroadcastMessages(t *testing.T) {
 		{
 			// A text message with emojis
 			Messages: []SendingMessage{
-				NewTextMessage("Look at this: $ It's a LINE emoji!").AddEmoji(
+				NewTextMessage("$ Look at this: $ It's a LINE emoji!").AddEmoji(
+					NewEmoji(0, "5ac1bfd5040ab15980c9b435", "086")).AddEmoji(
 					NewEmoji(14, "5ac1bfd5040ab15980c9b435", "001"),
 				),
 			},
 			ResponseCode: 200,
 			Response:     []byte(`{}`),
 			Want: want{
-				RequestBody: []byte(`{"messages":[{"type":"text","text":"Look at this: $ It's a LINE emoji!","emojis":[{"index":14,"productId":"5ac1bfd5040ab15980c9b435","emojiId":"001"}]}]}` + "\n"),
+				RequestBody: []byte(`{"messages":[{"type":"text","text":"Look at this: $ It's a LINE emoji!","emojis":[{"index":0,"productId":"5ac1bfd5040ab15980c9b435","emojiId":"086"},{"index":14,"productId":"5ac1bfd5040ab15980c9b435","emojiId":"001"}]}]}` + "\n"),
 				Response:    &BasicResponse{},
 			},
 		},


### PR DESCRIPTION
### Why need this change / Root cause
Original the `index` of emoji is omitempty it means if `index=0` it will be omitted. But server could not accept any call without `index`.

![image](https://user-images.githubusercontent.com/2252691/81898181-c3ea0080-95ea-11ea-849c-0efa4aa10eaf.png)


### Changes made
- Add one more test index=0.
- Remove omit empty on Emoji index.

### Verified screenshots (optional)



