### PR TITLE
Add API for Retry failed message

### DIFF
--- a/linebot/client.go
+++ b/linebot/client.go
@@ -88,6 +88,7 @@ type Client struct {
 	endpointBase     *url.URL     // default APIEndpointBase
 	endpointBaseData *url.URL     // default APIEndpointBaseData
 	httpClient       *http.Client // default http.DefaultClient
+	retryKeyID       string       // X-Line-Retry-Key allows you to safely retry API requests without duplicating messages
 }
 
 // ClientOption type
@@ -170,6 +171,10 @@ func (client *Client) url(base *url.URL, endpoint string) string {
 func (client *Client) do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+client.channelToken)
 	req.Header.Set("User-Agent", "LINE-BotSDK-Go/"+version)
+	if len(client.retryKeyID) > 0 {
+		req.Header.Set("X-Line-Retry-Key", client.retryKeyID)
+
+	}
 	if ctx != nil {
 		req = req.WithContext(ctx)
 	}
@@ -221,6 +226,10 @@ func (client *Client) delete(ctx context.Context, endpoint string) (*http.Respon
 		return nil, err
 	}
 	return client.do(ctx, req)
+}
+
+func (client *Client) setRetryKey(retryKey string) {
+	client.retryKeyID = retryKey
 }
 
 func closeResponse(res *http.Response) error {

--- a/linebot/client.go
+++ b/linebot/client.go
@@ -173,7 +173,6 @@ func (client *Client) do(ctx context.Context, req *http.Request) (*http.Response
 	req.Header.Set("User-Agent", "LINE-BotSDK-Go/"+version)
 	if len(client.retryKeyID) > 0 {
 		req.Header.Set("X-Line-Retry-Key", client.retryKeyID)
-
 	}
 	if ctx != nil {
 		req = req.WithContext(ctx)

--- a/linebot/send_message.go
+++ b/linebot/send_message.go
@@ -53,6 +53,12 @@ func (call *PushMessageCall) WithNotificationDisabled() *PushMessageCall {
 	return call
 }
 
+// WithRetryKey method will set retry key string (UUID) on PushMessage.
+func (call *PushMessageCall) WithRetryKey(retryKey string) *PushMessageCall {
+	call.c.setRetryKey(retryKey)
+	return call
+}
+
 func (call *PushMessageCall) encodeJSON(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	return enc.Encode(&struct {
@@ -171,6 +177,12 @@ func (call *MulticastCall) WithNotificationDisabled() *MulticastCall {
 	return call
 }
 
+// WithRetryKey method will set retry key string (UUID) on Multicast.
+func (call *MulticastCall) WithRetryKey(retryKey string) *MulticastCall {
+	call.c.setRetryKey(retryKey)
+	return call
+}
+
 func (call *MulticastCall) encodeJSON(w io.Writer) error {
 	enc := json.NewEncoder(w)
 	return enc.Encode(&struct {
@@ -217,6 +229,12 @@ type BroadcastMessageCall struct {
 // WithContext method
 func (call *BroadcastMessageCall) WithContext(ctx context.Context) *BroadcastMessageCall {
 	call.ctx = ctx
+	return call
+}
+
+// WithRetryKey method will set retry key string (UUID) on BroadcastMessage.
+func (call *BroadcastMessageCall) WithRetryKey(retryKey string) *BroadcastMessageCall {
+	call.c.setRetryKey(retryKey)
 	return call
 }
 
@@ -293,6 +311,12 @@ func (call *NarrowcastCall) WithDemographic(demographic DemographicFilter) *Narr
 // WithLimitMax method will set maximum number of recipients
 func (call *NarrowcastCall) WithLimitMax(max int) *NarrowcastCall {
 	call.limit = &NarrowcastMessageLimit{Max: max}
+	return call
+}
+
+// WithRetryKey method will set retry key string (UUID) on narrowcast.
+func (call *NarrowcastCall) WithRetryKey(retryKey string) *NarrowcastCall {
+	call.c.setRetryKey(retryKey)
 	return call
 }
 

--- a/linebot/send_message.go
+++ b/linebot/send_message.go
@@ -287,7 +287,8 @@ type Filter struct {
 
 // NarrowcastMessageLimit type
 type NarrowcastMessageLimit struct {
-	Max int `json:"max"`
+	Max                int  `json:"max"`
+	UpToRemainingQuota bool `json:"upToRemainingQuota,omitempty"`
 }
 
 // WithContext method
@@ -311,6 +312,18 @@ func (call *NarrowcastCall) WithDemographic(demographic DemographicFilter) *Narr
 // WithLimitMax method will set maximum number of recipients
 func (call *NarrowcastCall) WithLimitMax(max int) *NarrowcastCall {
 	call.limit = &NarrowcastMessageLimit{Max: max}
+	return call
+}
+
+// WithRetryKey method will set retry key string (UUID) on narrowcast.
+func (call *NarrowcastCall) WithRetryKey(retryKey string) *NarrowcastCall {
+	call.c.setRetryKey(retryKey)
+	return call
+}
+
+// WithLimitMaxUpToRemainingQuota method will set maximum number of recipients but not over remaining quota.
+func (call *NarrowcastCall) WithLimitMaxUpToRemainingQuota(max int, upToRemainingQuota bool) *NarrowcastCall {
+	call.limit = &NarrowcastMessageLimit{Max: max, UpToRemainingQuota: upToRemainingQuota}
 	return call
 }
 

--- a/linebot/send_message_test.go
+++ b/linebot/send_message_test.go
@@ -1642,15 +1642,16 @@ func TestNarrowcastMessages(t *testing.T) {
 		Error       error
 	}
 	var testCases = []struct {
-		Label        string
-		Messages     []SendingMessage
-		Recipient    Recipient
-		Demographic  DemographicFilter
-		Max          int
-		RequestID    string
-		Response     []byte
-		ResponseCode int
-		Want         want
+		Label              string
+		Messages           []SendingMessage
+		Recipient          Recipient
+		Demographic        DemographicFilter
+		Max                int
+		UpToRemainingQuota bool
+		RequestID          string
+		Response           []byte
+		ResponseCode       int
+		Want               want
 	}{
 		{
 			Label:    "A text message for Narrowcast Message with Audience",
@@ -1686,16 +1687,17 @@ func TestNarrowcastMessages(t *testing.T) {
 			},
 		},
 		{
-			Label:        "A text message for Narrowcast Message for male and age >= 30 and limit max to 10",
-			Messages:     []SendingMessage{NewTextMessage("Hello, world")},
-			Recipient:    nil,
-			Demographic:  DemographicFilterOperatorAnd(NewGenderFilter(GenderMale), NewAgeFilter(Age30, AgeEmpty)),
-			Max:          10,
-			RequestID:    "32222",
-			Response:     []byte(`{}`),
-			ResponseCode: 202,
+			Label:              "A text message for Narrowcast Message for male and age >= 30 and limit max to 10",
+			Messages:           []SendingMessage{NewTextMessage("Hello, world")},
+			Recipient:          nil,
+			Demographic:        DemographicFilterOperatorAnd(NewGenderFilter(GenderMale), NewAgeFilter(Age30, AgeEmpty)),
+			Max:                10,
+			UpToRemainingQuota: true,
+			RequestID:          "32222",
+			Response:           []byte(`{}`),
+			ResponseCode:       202,
 			Want: want{
-				RequestBody: []byte(`{"messages":[{"type":"text","text":"Hello, world"}],"filter":{"demographic":{"type":"operator","and":[{"type":"gender","oneOf":["male"]},{"type":"age","gte":"age_30"}]}},"limit":{"max":10}}` + "\n"),
+				RequestBody: []byte(`{"messages":[{"type":"text","text":"Hello, world"}],"filter":{"demographic":{"type":"operator","and":[{"type":"gender","oneOf":["male"]},{"type":"age","gte":"age_30"}]}},"limit":{"max":10,"upToRemainingQuota":true}}` + "\n"),
 				Response:    &BasicResponse{RequestID: "32222"},
 			},
 		},
@@ -1777,6 +1779,9 @@ func TestNarrowcastMessages(t *testing.T) {
 			if tc.Max > 0 {
 				narrowCast = narrowCast.WithLimitMax(tc.Max)
 			}
+			if tc.UpToRemainingQuota {
+				narrowCast = narrowCast.WithLimitMaxUpToRemainingQuota(tc.Max, tc.UpToRemainingQuota)
+			}
 			res, err := narrowCast.Do()
 			if tc.Want.Error != nil {
 				if !reflect.DeepEqual(err, tc.Want.Error) {
@@ -1818,6 +1823,138 @@ func BenchmarkPushMessages(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		client.PushMessage("U0cc15697597f61dd8b01cea8b027050e", NewTextMessage("Hello, world")).Do()
+	}
+}
+
+func TestMessagesWithRetryKey(t *testing.T) {
+	type testMethod interface {
+		Do() (*BasicResponse, error)
+	}
+	var toUserIDs = []string{
+		"U0cc15697597f61dd8b01cea8b027050e",
+		"U38ecbecfade326557b6971140741a4a6",
+	}
+	var msgUUIDs string = "123e4567-e89b-12d3-a456-426655440002"
+
+	type want struct {
+		RequestBody []byte
+		Response    *BasicResponse
+		Error       error
+	}
+	var testCases = []struct {
+		Label        string
+		TestMethod   testMethod
+		Messages     []SendingMessage
+		Response     []byte
+		ResponseCode int
+		Want         want
+	}{
+		{
+			Label:        "A text message for Push Message",
+			TestMethod:   new(PushMessageCall),
+			Messages:     []SendingMessage{NewTextMessage("Hello, world")},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"to":"U0cc15697597f61dd8b01cea8b027050e","messages":[{"type":"text","text":"Hello, world"}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
+			Label:        "A text message for Multicast",
+			TestMethod:   new(MulticastCall),
+			Messages:     []SendingMessage{NewTextMessage("Hello, world")},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"to":["U0cc15697597f61dd8b01cea8b027050e","U38ecbecfade326557b6971140741a4a6"],"messages":[{"type":"text","text":"Hello, world"}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
+			Label:        "A text message for Narrowcast",
+			TestMethod:   new(NarrowcastCall),
+			Messages:     []SendingMessage{NewTextMessage("Hello, world")},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"messages":[{"type":"text","text":"Hello, world"}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+		{
+			Label:        "A text message for Broadcast",
+			TestMethod:   new(BroadcastMessageCall),
+			Messages:     []SendingMessage{NewTextMessage("Hello, world")},
+			ResponseCode: 200,
+			Response:     []byte(`{}`),
+			Want: want{
+				RequestBody: []byte(`{"messages":[{"type":"text","text":"Hello, world"}]}` + "\n"),
+				Response:    &BasicResponse{},
+			},
+		},
+	}
+
+	var currentTestIdx int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if r.Method != http.MethodPost {
+			t.Errorf("Method %s; want %s", r.Method, http.MethodPost)
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tc := testCases[currentTestIdx]
+		if !reflect.DeepEqual(body, tc.Want.RequestBody) {
+			t.Errorf("RequestBody %s; want %s", body, tc.Want.RequestBody)
+		}
+		w.WriteHeader(tc.ResponseCode)
+		w.Write(tc.Response)
+	}))
+	defer server.Close()
+
+	dataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		t.Error("Unexpected data API call")
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"Not found"}`))
+	}))
+	defer dataServer.Close()
+
+	client, err := mockClient(server, dataServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res *BasicResponse
+	for i, tc := range testCases {
+		currentTestIdx = i
+		t.Run(strconv.Itoa(i)+"/"+tc.Label, func(t *testing.T) {
+			switch tc.TestMethod.(type) {
+			case *PushMessageCall:
+				res, err = client.PushMessage(toUserIDs[0], tc.Messages...).WithRetryKey(msgUUIDs).Do()
+			case *MulticastCall:
+				res, err = client.Multicast(toUserIDs, tc.Messages...).WithRetryKey(msgUUIDs).Do()
+			case *NarrowcastCall:
+				res, err = client.Narrowcast(tc.Messages...).WithRetryKey(msgUUIDs).Do()
+			case *BroadcastMessageCall:
+				res, err = client.BroadcastMessage(tc.Messages...).WithRetryKey(msgUUIDs).Do()
+			}
+			if tc.Want.Error != nil {
+				if !reflect.DeepEqual(err, tc.Want.Error) {
+					t.Errorf("Error %d %v; want %v", i, err, tc.Want.Error)
+				}
+			} else {
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			if tc.Want.Response != nil {
+				if !reflect.DeepEqual(res, tc.Want.Response) {
+					t.Errorf("Response %d %v; want %v", i, res, tc.Want.Response)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixed #207  
API for Retry failed message 
Refer: https://developers.line.biz/en/reference/messaging-api/#retry-api-request