### PR TITLE
Add redelivery object for narrowcast

### DIFF
--- a/linebot/recipient.go
+++ b/linebot/recipient.go
@@ -38,6 +38,23 @@ func NewAudienceObject(groupID int) *AudienceObject {
 // Recipient implements Recipient interface
 func (*AudienceObject) Recipient() {}
 
+// RedeliveryObject type is created to be used with specific recipient objects
+type RedeliveryObject struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+}
+
+// NewRedeliveryObject function
+func NewRedeliveryObject(requestID string) *RedeliveryObject {
+	return &RedeliveryObject{
+		Type:      "redelivery",
+		RequestID: requestID,
+	}
+}
+
+// Recipient implements Recipient interface
+func (*RedeliveryObject) Recipient() {}
+
 // RecipientOperator struct
 type RecipientOperator struct {
 	ConditionAnd []Recipient `json:"and,omitempty"`

--- a/linebot/send_message_test.go
+++ b/linebot/send_message_test.go
@@ -1673,6 +1673,25 @@ func TestNarrowcastMessages(t *testing.T) {
 			},
 		},
 		{
+			Label:    "A text message for Narrowcast Message with Redelivery",
+			Messages: []SendingMessage{NewTextMessage("Hello, world")},
+			Recipient: RecipientOperatorAnd(
+				NewRedeliveryObject("f70dd685-499a-4231-a441-f24b8d4fba21"),
+				RecipientOperatorNot(
+					NewRedeliveryObject("x88dd9k2-gdd4-7fs0-a441-va668d4fb0x9"),
+				),
+			),
+			Demographic:  nil,
+			Max:          0,
+			RequestID:    "12222",
+			Response:     []byte(`{}`),
+			ResponseCode: 202,
+			Want: want{
+				RequestBody: []byte(`{"messages":[{"type":"text","text":"Hello, world"}],"recipient":{"type":"operator","and":[{"type":"redelivery","requestId":"f70dd685-499a-4231-a441-f24b8d4fba21"},{"type":"operator","not":{"type":"redelivery","requestId":"x88dd9k2-gdd4-7fs0-a441-va668d4fb0x9"}}]}}` + "\n"),
+				Response:    &BasicResponse{RequestID: "12222"},
+			},
+		},
+		{
 			Label:        "A text message for Narrowcast Message for android",
 			Messages:     []SendingMessage{NewTextMessage("Hello, world")},
 			Recipient:    nil,


### PR DESCRIPTION
[#230](https://github.com/line/line-bot-sdk-go/issues/230)
[https://developers.line.biz/en/reference/messaging-api/#narrowcast-recipient](https://developers.line.biz/en/reference/messaging-api/#narrowcast-recipient)