### PR TITLE
Add generic request method. #258

### DIFF
--- a/linebot/client.go
+++ b/linebot/client.go
@@ -185,6 +185,10 @@ func (client *Client) do(ctx context.Context, req *http.Request) (*http.Response
 	return client.httpClient.Do(req)
 }
 
+func (client *Client) request(ctx context.Context, req *http.Request) (*http.Response, error) {
+	return client.do(ctx, req)
+}
+
 func (client *Client) get(ctx context.Context, base *url.URL, endpoint string, query url.Values) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, client.url(base, endpoint), nil)
 	if err != nil {

--- a/linebot/client.go
+++ b/linebot/client.go
@@ -185,10 +185,6 @@ func (client *Client) do(ctx context.Context, req *http.Request) (*http.Response
 	return client.httpClient.Do(req)
 }
 
-func (client *Client) request(ctx context.Context, req *http.Request) (*http.Response, error) {
-	return client.do(ctx, req)
-}
-
 func (client *Client) get(ctx context.Context, base *url.URL, endpoint string, query url.Values) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, client.url(base, endpoint), nil)
 	if err != nil {

--- a/linebot/raw.go
+++ b/linebot/raw.go
@@ -65,5 +65,5 @@ func (call *RawCall) WithContext(ctx context.Context) *RawCall {
 
 // Do method. Callee must close response object.
 func (call *RawCall) Do() (*http.Response, error) {
-	return call.c.request(call.ctx, call.req)
+	return call.c.do(call.ctx, call.req)
 }

--- a/linebot/raw.go
+++ b/linebot/raw.go
@@ -1,0 +1,166 @@
+// Copyright 2021 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package linebot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// GetRaw method
+func (client *Client) GetRaw(endpoint string, query url.Values) *GetRawCall {
+	return &GetRawCall{
+		c: client,
+		endpoint: endpoint,
+		query: query,
+	}
+}
+
+// GetRawCall type
+type GetRawCall struct {
+	c   *Client
+	ctx context.Context
+
+	endpoint string
+	query url.Values
+}
+
+// WithContext method
+func (call *GetRawCall) WithContext(ctx context.Context) *GetRawCall {
+	call.ctx = ctx
+	return call
+}
+
+// Do method. Callee must close response object.
+func (call *GetRawCall) Do() (*http.Response, error) {
+	return call.c.get(call.ctx, call.c.endpointBase, call.endpoint, call.query)
+}
+
+// PostRaw method
+func (client *Client) PostRaw(endpoint string, body io.Reader) *PostRawCall {
+	return &PostRawCall{
+		c: client,
+		endpoint: endpoint,
+		body: body,
+	}
+}
+
+// PostRawCall type
+type PostRawCall struct {
+	c   *Client
+	ctx context.Context
+
+	endpoint string
+	body io.Reader
+}
+
+// WithContext method
+func (call *PostRawCall) WithContext(ctx context.Context) *PostRawCall {
+	call.ctx = ctx
+	return call
+}
+
+// Do method. Callee must close response object.
+func (call *PostRawCall) Do() (*http.Response, error) {
+	return call.c.post(call.ctx, call.endpoint, call.body)
+}
+
+// PostFormRaw method
+func (client *Client) PostFormRaw(endpoint string, body io.Reader) *PostFormRawCall {
+	return &PostFormRawCall{
+		c: client,
+
+		endpoint: endpoint,
+		body: body,
+	}
+}
+
+// PostFormRawCall type
+type PostFormRawCall struct {
+	c   *Client
+	ctx context.Context
+
+	endpoint string
+	body io.Reader
+}
+
+// WithContext method
+func (call *PostFormRawCall) WithContext(ctx context.Context) *PostFormRawCall {
+	call.ctx = ctx
+	return call
+}
+
+// Do method. Callee must close response object.
+func (call *PostFormRawCall) Do() (*http.Response, error) {
+	return call.c.postform(call.ctx, call.endpoint, call.body)
+}
+
+// PutRaw method
+func (client *Client) PutRaw(endpoint string, body io.Reader) *PutRawCall {
+	return &PutRawCall{
+		c:        client,
+		endpoint: endpoint,
+		body: body,
+	}
+}
+
+// PutRawCall type
+type PutRawCall struct {
+	c   *Client
+	ctx context.Context
+
+	endpoint string
+	body     io.Reader
+}
+
+// WithContext method
+func (call *PutRawCall) WithContext(ctx context.Context) *PutRawCall {
+	call.ctx = ctx
+	return call
+}
+
+// Do method. Callee must close response object.
+func (call *PutRawCall) Do() (*http.Response, error) {
+	return call.c.put(call.ctx, call.endpoint, call.body)
+}
+
+// DeleteRaw method
+func (client *Client) DeleteRaw(endpoint string) *DeleteRawCall {
+	return &DeleteRawCall{
+		c:        client,
+		endpoint: endpoint,
+	}
+}
+
+// DeleteRawCall type
+type DeleteRawCall struct {
+	c   *Client
+	ctx context.Context
+
+	endpoint string
+}
+
+// WithContext method
+func (call *DeleteRawCall) WithContext(ctx context.Context) *DeleteRawCall {
+	call.ctx = ctx
+	return call
+}
+
+// Do method. Callee must close response object.
+func (call *DeleteRawCall) Do() (*http.Response, error) {
+	return call.c.delete(call.ctx, call.endpoint)
+}

--- a/linebot/raw_test.go
+++ b/linebot/raw_test.go
@@ -1,0 +1,176 @@
+// Copyright 2021 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package linebot
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+type requestWant struct {
+	Path        string
+	Method      string
+	ContentType string
+	RequestBody []byte
+}
+
+type responseWant struct {
+	Status       int
+	ResponseBody []byte
+}
+type testcase struct {
+	ResponseCode int
+	Response     []byte
+	ResponseWant responseWant
+	RequestWant  requestWant
+	Call         func(client *Client) (*http.Response, error)
+}
+
+func TestPostFormRaw(t *testing.T) {
+	testcases := []testcase{
+		newTestCase(
+			http.MethodGet,
+			"",
+			[]byte(""),
+			func(client *Client) (*http.Response, error) {
+				return client.GetRaw("/abcdefg", nil).Do()
+			},
+		),
+		newTestCase(
+			http.MethodPost,
+			"application/json; charset=UTF-8",
+			[]byte(`RRRREQUEST_BODY`),
+			func(client *Client) (*http.Response, error) {
+				return client.PostRaw("/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`))).Do()
+			},
+		),
+		newTestCase(
+			http.MethodPost,
+			"application/x-www-form-urlencoded",
+			[]byte(`RRRREQUEST_BODY`),
+			func(client *Client) (*http.Response, error) {
+				return client.PostFormRaw("/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`))).Do()
+			},
+		),
+		newTestCase(
+			http.MethodPut,
+			"application/json; charset=UTF-8",
+			[]byte(`RRRREQUEST_BODY`),
+			func(client *Client) (*http.Response, error) {
+				return client.PutRaw("/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`))).Do()
+			},
+		),
+		newTestCase(
+			http.MethodDelete,
+			"",
+			[]byte(``),
+			func(client *Client) (*http.Response, error) {
+				return client.DeleteRaw("/abcdefg").Do()
+			},
+		),
+	}
+
+	for i, tc := range testcases {
+		t.Run(strconv.Itoa(i) + "_" + tc.RequestWant.Method, func(t *testing.T) {
+			runTestCase(t, tc)
+		})
+	}
+}
+
+func newTestCase(expectedRequestMethod string,
+	expectedRequestContentType string,
+	expectedRequestBody []byte,
+	call func(client *Client) (*http.Response, error)) testcase {
+	return testcase{
+		ResponseCode: 200,
+		Response:     []byte(`TESTDATA`),
+		Call:         call,
+		RequestWant: requestWant{
+			Method:      expectedRequestMethod,
+			Path:        "/abcdefg",
+			RequestBody: expectedRequestBody,
+			ContentType: expectedRequestContentType,
+		},
+		ResponseWant: responseWant{
+			Status:       200,
+			ResponseBody: []byte(`TESTDATA`),
+		},
+	}
+}
+
+func runTestCase(t *testing.T, tc testcase) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if r.Method != tc.RequestWant.Method {
+			t.Errorf("Method %s; want %s", r.Method, tc.RequestWant.Method)
+		}
+		endpoint := APIEndpointGetAllLIFFApps
+		if r.URL.Path != tc.RequestWant.Path {
+			t.Errorf("URLPath %s; want %s", r.URL.Path, endpoint)
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		contentType := r.Header.Get("content-type")
+		if !reflect.DeepEqual(contentType, tc.RequestWant.ContentType) {
+			t.Errorf("Content\n %v; want\n %v", contentType, tc.RequestWant.ContentType)
+		}
+
+		if tc.RequestWant.RequestBody != nil {
+			if !reflect.DeepEqual(body, tc.RequestWant.RequestBody) {
+				t.Errorf("RequestBody\n %s; want\n %s", body, tc.RequestWant.RequestBody)
+			}
+		}
+
+		w.WriteHeader(tc.ResponseCode)
+		w.Write(tc.Response)
+	}))
+	defer server.Close()
+
+	dataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		t.Error("Unexpected data API call")
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"Not found"}`))
+	}))
+	defer dataServer.Close()
+
+	client, err := mockClient(server, dataServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := tc.Call(client)
+	defer res.Body.Close()
+	if err != nil {
+		t.Error(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(body, tc.ResponseWant.ResponseBody) {
+		t.Errorf("Response %v; want %v", body, tc.ResponseWant.ResponseBody)
+	}
+	if res.StatusCode != tc.ResponseWant.Status {
+		t.Errorf("Response %v; want %v", res.StatusCode, tc.ResponseWant.Status)
+	}
+}

--- a/linebot/raw_test.go
+++ b/linebot/raw_test.go
@@ -43,14 +43,18 @@ type testcase struct {
 	Call         func(client *Client) (*http.Response, error)
 }
 
-func TestPostFormRaw(t *testing.T) {
+func TestRaw(t *testing.T) {
 	testcases := []testcase{
 		newTestCase(
 			http.MethodGet,
 			"",
 			[]byte(""),
 			func(client *Client) (*http.Response, error) {
-				return client.GetRaw("/abcdefg", nil).Do()
+				call, err := client.NewRawCall(http.MethodGet, "/abcdefg")
+				if err != nil {
+					panic(err)
+				}
+				return call.Do()
 			},
 		),
 		newTestCase(
@@ -58,7 +62,12 @@ func TestPostFormRaw(t *testing.T) {
 			"application/json; charset=UTF-8",
 			[]byte(`RRRREQUEST_BODY`),
 			func(client *Client) (*http.Response, error) {
-				return client.PostRaw("/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`))).Do()
+				call, err := client.NewRawCallWithBody(http.MethodPost, "/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`)))
+				if err != nil {
+					panic(err)
+				}
+				call.AddHeader("content-type", "application/json; charset=UTF-8")
+				return call.Do()
 			},
 		),
 		newTestCase(
@@ -66,7 +75,12 @@ func TestPostFormRaw(t *testing.T) {
 			"application/x-www-form-urlencoded",
 			[]byte(`RRRREQUEST_BODY`),
 			func(client *Client) (*http.Response, error) {
-				return client.PostFormRaw("/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`))).Do()
+				call, err := client.NewRawCallWithBody(http.MethodPost, "/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`)))
+				if err != nil {
+					panic(err)
+				}
+				call.AddHeader("content-type", "application/x-www-form-urlencoded")
+				return call.Do()
 			},
 		),
 		newTestCase(
@@ -74,7 +88,12 @@ func TestPostFormRaw(t *testing.T) {
 			"application/json; charset=UTF-8",
 			[]byte(`RRRREQUEST_BODY`),
 			func(client *Client) (*http.Response, error) {
-				return client.PutRaw("/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`))).Do()
+				call, err := client.NewRawCallWithBody(http.MethodPut, "/abcdefg", bytes.NewReader([]byte(`RRRREQUEST_BODY`)))
+				if err != nil {
+					panic(err)
+				}
+				call.AddHeader("content-type", "application/json; charset=UTF-8")
+				return call.Do()
 			},
 		),
 		newTestCase(
@@ -82,13 +101,17 @@ func TestPostFormRaw(t *testing.T) {
 			"",
 			[]byte(``),
 			func(client *Client) (*http.Response, error) {
-				return client.DeleteRaw("/abcdefg").Do()
+				call, err := client.NewRawCall(http.MethodDelete, "/abcdefg")
+				if err != nil {
+					panic(err)
+				}
+				return call.Do()
 			},
 		),
 	}
 
 	for i, tc := range testcases {
-		t.Run(strconv.Itoa(i) + "_" + tc.RequestWant.Method, func(t *testing.T) {
+		t.Run(strconv.Itoa(i)+"_"+tc.RequestWant.Method, func(t *testing.T) {
 			runTestCase(t, tc)
 		})
 	}
@@ -121,9 +144,8 @@ func runTestCase(t *testing.T, tc testcase) {
 		if r.Method != tc.RequestWant.Method {
 			t.Errorf("Method %s; want %s", r.Method, tc.RequestWant.Method)
 		}
-		endpoint := APIEndpointGetAllLIFFApps
 		if r.URL.Path != tc.RequestWant.Path {
-			t.Errorf("URLPath %s; want %s", r.URL.Path, endpoint)
+			t.Errorf("URLPath %s; want %s", r.URL.Path, tc.RequestWant.Path)
 		}
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {


### PR DESCRIPTION
SDK users can call APIs without waiting for SDK's development(usually, SDK's development is a bit delayed from API release)