### PR TITLE
add background props to BoxComponent

### DIFF
--- a/linebot/flex.go
+++ b/linebot/flex.go
@@ -320,6 +320,14 @@ const (
 	FlexComponentAdjustModeTypeShrinkToFit FlexComponentAdjustModeType = "shrink-to-fit"
 )
 
+// FlexBoxBackgroundType type
+type FlexBoxBackgroundType string
+
+// FlexBoxBackgroundType constants
+const (
+	FlexBoxBackgroundTypeLinearGradient FlexBoxBackgroundType = "linearGradient"
+)
+
 // FlexContainer interface
 type FlexContainer interface {
 	FlexContainer()
@@ -445,6 +453,7 @@ type BoxComponent struct {
 	Action          TemplateAction
 	JustifyContent  FlexComponentJustifyContentType
 	AlignItems      FlexComponentAlignItemsType
+	Background      *BoxBackground
 }
 
 // MarshalJSON method of BoxComponent
@@ -464,6 +473,7 @@ func (c *BoxComponent) MarshalJSON() ([]byte, error) {
 		Action          TemplateAction                  `json:"action,omitempty"`
 		JustifyContent  FlexComponentJustifyContentType `json:"justifyContent,omitempty"`
 		AlignItems      FlexComponentAlignItemsType     `json:"alignItems,omitempty"`
+		Background      *BoxBackground                  `json:"background,omitempty"`
 	}{
 		Type:            FlexComponentTypeBox,
 		Layout:          c.Layout,
@@ -479,7 +489,18 @@ func (c *BoxComponent) MarshalJSON() ([]byte, error) {
 		Action:          c.Action,
 		JustifyContent:  c.JustifyContent,
 		AlignItems:      c.AlignItems,
+		Background:      c.Background,
 	})
+}
+
+// BoxBackground type
+type BoxBackground struct {
+	Type           FlexBoxBackgroundType `json:"type,omitempty"`
+	Angle          string                `json:"angle,omitempty"`
+	StartColor     string                `json:"startColor,omitempty"`
+	EndColor       string                `json:"endColor,omitempty"`
+	CenterColor    string                `json:"centerColor,omitempty"`
+	CenterPosition string                `json:"centerPosition,omitempty"`
 }
 
 // ButtonComponent type

--- a/linebot/flex_test.go
+++ b/linebot/flex_test.go
@@ -473,8 +473,8 @@ func TestUnmarshalFlexMessageJSON(t *testing.T) {
 									Desktop: "https://line.me/ja/download",
 								},
 							},
-							Height: FlexButtonHeightTypeSm,
-							Style:  FlexButtonStyleTypeLink,
+							Height:     FlexButtonHeightTypeSm,
+							Style:      FlexButtonStyleTypeLink,
 							AdjustMode: FlexComponentAdjustModeTypeShrinkToFit,
 						},
 						&SpacerComponent{
@@ -635,7 +635,15 @@ func TestUnmarshalFlexMessageJSON(t *testing.T) {
         "layout": "vertical",
         "contents": [],
         "width": "30px",
-        "height": "30px"
+        "height": "30px",
+        "background": {
+          "type": "linearGradient",
+          "angle": "0deg",
+          "startColor": "#ff0000",
+          "centerColor": "#0000ff",
+          "endColor": "#00ff00",
+          "centerPosition": "10%"
+        }
       }
     ],
     "height": "400px",
@@ -668,6 +676,14 @@ func TestUnmarshalFlexMessageJSON(t *testing.T) {
 							Contents: []FlexComponent{},
 							Width:    "30px",
 							Height:   "30px",
+							Background: &BoxBackground{
+								Type:           FlexBoxBackgroundTypeLinearGradient,
+								Angle:          "0deg",
+								StartColor:     "#ff0000",
+								EndColor:       "#00ff00",
+								CenterColor:    "#0000ff",
+								CenterPosition: "10%",
+							},
 						},
 					},
 					Height:         "400px",


### PR DESCRIPTION
#234 
3. Use linear gradient as the background image for a box component by setting its background.type property equal to linearGradient.