### PR TITLE
upgrade major version to v7 for meets the specification of go module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ See the official API documentation for more information.
 
 ## Requirements
 
-This library requires Go 1.10 or later.
+This library requires Go 1.11 or later.
 
 ## Installation ##
 
 ```sh
-$ go get github.com/line/line-bot-sdk-go/linebot
+$ go get -u github.com/line/line-bot-sdk-go/v7/linebot
 ```
 
 ## Configuration ##
 
 ```go
 import (
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func main() {

--- a/examples/access_token_helper/main.go
+++ b/examples/access_token_helper/main.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func main() {

--- a/examples/delivery_helper/main.go
+++ b/examples/delivery_helper/main.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func main() {

--- a/examples/echo_bot/server.go
+++ b/examples/echo_bot/server.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func main() {

--- a/examples/echo_bot_handler/server.go
+++ b/examples/echo_bot_handler/server.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/linebot"
-	"github.com/line/line-bot-sdk-go/linebot/httphandler"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot/httphandler"
 )
 
 func main() {

--- a/examples/insight_helper/main.go
+++ b/examples/insight_helper/main.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func main() {

--- a/examples/kitchensink/server.go
+++ b/examples/kitchensink/server.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func main() {

--- a/examples/richmenu_helper/main.go
+++ b/examples/richmenu_helper/main.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/line/line-bot-sdk-go
+module github.com/line/line-bot-sdk-go/v7
 
 go 1.11
 

--- a/linebot/example_test.go
+++ b/linebot/example_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 func ExampleIDsScanner() {

--- a/linebot/httphandler/httphandler.go
+++ b/linebot/httphandler/httphandler.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 // EventsHandlerFunc type

--- a/linebot/httphandler/httphandler_test.go
+++ b/linebot/httphandler/httphandler_test.go
@@ -24,7 +24,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
 )
 
 var testRequestBody = `{


### PR DESCRIPTION
Since PR #264 enabled the go module, it‘s better to follow the [specification of the go module](https://blog.golang.org/v2-go-modules) to upgrade the major version. 

Currently, The latest version of package still stuck at v1.3.0 [pkg.go.dev](https://pkg.go.dev/github.com/line/line-bot-sdk-go/linebot) This change will help the version control back to the major line