### PR TITLE
Fix wrong constant type & other fixes

### DIFF
--- a/examples/kitchensink/server.go
+++ b/examples/kitchensink/server.go
@@ -727,11 +727,11 @@ func (app *KitchenSink) handleHeavyContent(messageID string, callback func(*os.F
 	}
 	defer content.Content.Close()
 	log.Printf("Got file: %s", content.ContentType)
-	originalConent, err := app.saveContent(content.Content)
+	originalContent, err := app.saveContent(content.Content)
 	if err != nil {
 		return err
 	}
-	return callback(originalConent)
+	return callback(originalContent)
 }
 
 func (app *KitchenSink) saveContent(content io.ReadCloser) (*os.File, error) {

--- a/linebot/client.go
+++ b/linebot/client.go
@@ -206,7 +206,7 @@ func (client *Client) post(ctx context.Context, endpoint string, body io.Reader)
 	return client.do(ctx, req)
 }
 
-func (client *Client) postform(ctx context.Context, endpoint string, body io.Reader) (*http.Response, error) {
+func (client *Client) postForm(ctx context.Context, endpoint string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest("POST", client.url(client.endpointBase, endpoint), body)
 	if err != nil {
 		return nil, err

--- a/linebot/event.go
+++ b/linebot/event.go
@@ -133,7 +133,7 @@ type ThingsResult struct {
 // ThingsResultCode type
 type ThingsResultCode string
 
-// ThingsResultCode constsnts
+// ThingsResultCode constants
 const (
 	ThingsResultCodeSuccess      ThingsResultCode = "success"
 	ThingsResultCodeGattError    ThingsResultCode = "gatt_error"
@@ -149,7 +149,7 @@ type ThingsActionResult struct {
 // ThingsActionResultType type
 type ThingsActionResultType string
 
-// ThingsActionResultType contants
+// ThingsActionResultType constants
 const (
 	ThingsActionResultTypeBinary ThingsActionResultType = "binary"
 	ThingsActionResultTypeVoid   ThingsActionResultType = "void"
@@ -280,8 +280,8 @@ type rawThingsEvent struct {
 }
 
 const (
-	millisecPerSec     = int64(time.Second / time.Millisecond)
-	nanosecPerMillisec = int64(time.Millisecond / time.Nanosecond)
+	milliSecPerSec     = int64(time.Second / time.Millisecond)
+	nanoSecPerMilliSec = int64(time.Millisecond / time.Nanosecond)
 )
 
 // MarshalJSON method of Event
@@ -290,7 +290,7 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 		ReplyToken:        e.ReplyToken,
 		Type:              e.Type,
 		Mode:              e.Mode,
-		Timestamp:         e.Timestamp.Unix()*millisecPerSec + int64(e.Timestamp.Nanosecond())/int64(time.Millisecond),
+		Timestamp:         e.Timestamp.Unix()*milliSecPerSec + int64(e.Timestamp.Nanosecond())/int64(time.Millisecond),
 		Source:            e.Source,
 		Postback:          e.Postback,
 		Unsend:            e.Unsend,
@@ -411,7 +411,7 @@ func (e *Event) UnmarshalJSON(body []byte) (err error) {
 	e.ReplyToken = rawEvent.ReplyToken
 	e.Type = rawEvent.Type
 	e.Mode = rawEvent.Mode
-	e.Timestamp = time.Unix(rawEvent.Timestamp/millisecPerSec, (rawEvent.Timestamp%millisecPerSec)*nanosecPerMillisec).UTC()
+	e.Timestamp = time.Unix(rawEvent.Timestamp/milliSecPerSec, (rawEvent.Timestamp%milliSecPerSec)*nanoSecPerMilliSec).UTC()
 	e.Source = rawEvent.Source
 
 	switch rawEvent.Type {

--- a/linebot/flex_test.go
+++ b/linebot/flex_test.go
@@ -695,7 +695,7 @@ func TestUnmarshalFlexMessageJSON(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			container, err := UnmarshalFlexMessageJSON([]byte(tc.JSON))
+			container, err := UnmarshalFlexMessageJSON(tc.JSON)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -753,7 +753,7 @@ func TestMarshalJSON(t *testing.T) {
 }
 
 func BenchmarkUnmarshalFlexMessageJSON(b *testing.B) {
-	var json = []byte(`{
+	var jsonData = []byte(`{
 		"type": "bubble",
 		"header": {
 			"type": "box",
@@ -891,7 +891,7 @@ func BenchmarkUnmarshalFlexMessageJSON(b *testing.B) {
 	}`)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := UnmarshalFlexMessageJSON(json)
+		_, err := UnmarshalFlexMessageJSON(jsonData)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/linebot/get_bot_info.go
+++ b/linebot/get_bot_info.go
@@ -24,7 +24,7 @@ type ChatMode string
 // ChatMode constants
 const (
 	ChatModeChat ChatMode = "chat"
-	ChatModeBot           = "bot"
+	ChatModeBot  ChatMode = "bot"
 )
 
 // MarkAsReadMode type
@@ -33,7 +33,7 @@ type MarkAsReadMode string
 // MarkAsReadMode constants
 const (
 	MarkAsReadModeManual MarkAsReadMode = "manual"
-	MarkAsReadModeAuto                  = "auto"
+	MarkAsReadModeAuto   MarkAsReadMode = "auto"
 )
 
 // GetBotInfo method

--- a/linebot/httphandler/httphandler_test.go
+++ b/linebot/httphandler/httphandler_test.go
@@ -121,7 +121,7 @@ func TestWebhookHandler(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		req.Header.Set("X-LINE-Signature", "invalidsignatue")
+		req.Header.Set("X-LINE-Signature", "invalidSignature")
 		res, err := httpClient.Do(req)
 		if err != nil {
 			t.Fatal(err)

--- a/linebot/message.go
+++ b/linebot/message.go
@@ -54,7 +54,7 @@ type TextMessage struct {
 	Text   string
 	Emojis []*Emoji
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 
 	Mention *Mention
@@ -71,7 +71,7 @@ func (m *TextMessage) MarshalJSON() ([]byte, error) {
 	}{
 		Type:       MessageTypeText,
 		Text:       m.Text,
-		QuickReply: m.quickReplyitems,
+		QuickReply: m.quickReplyItems,
 		Sender:     m.sender,
 		Emojis:     m.Emojis,
 	})
@@ -79,7 +79,7 @@ func (m *TextMessage) MarshalJSON() ([]byte, error) {
 
 // WithQuickReplies method of TextMessage
 func (m *TextMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -101,7 +101,7 @@ type ImageMessage struct {
 	OriginalContentURL string
 	PreviewImageURL    string
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -117,14 +117,14 @@ func (m *ImageMessage) MarshalJSON() ([]byte, error) {
 		Type:               MessageTypeImage,
 		OriginalContentURL: m.OriginalContentURL,
 		PreviewImageURL:    m.PreviewImageURL,
-		QuickReply:         m.quickReplyitems,
+		QuickReply:         m.quickReplyItems,
 		Sender:             m.sender,
 	})
 }
 
 // WithQuickReplies method of ImageMessage
 func (m *ImageMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -145,7 +145,7 @@ type VideoMessage struct {
 	OriginalContentURL string
 	PreviewImageURL    string
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -161,14 +161,14 @@ func (m *VideoMessage) MarshalJSON() ([]byte, error) {
 		Type:               MessageTypeVideo,
 		OriginalContentURL: m.OriginalContentURL,
 		PreviewImageURL:    m.PreviewImageURL,
-		QuickReply:         m.quickReplyitems,
+		QuickReply:         m.quickReplyItems,
 		Sender:             m.sender,
 	})
 }
 
 // WithQuickReplies method of VideoMessage
 func (m *VideoMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -189,7 +189,7 @@ type AudioMessage struct {
 	OriginalContentURL string
 	Duration           int
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -205,14 +205,14 @@ func (m *AudioMessage) MarshalJSON() ([]byte, error) {
 		Type:               MessageTypeAudio,
 		OriginalContentURL: m.OriginalContentURL,
 		Duration:           m.Duration,
-		QuickReply:         m.quickReplyitems,
+		QuickReply:         m.quickReplyItems,
 		Sender:             m.sender,
 	})
 }
 
 // WithQuickReplies method of AudioMessage
 func (m *AudioMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -242,7 +242,7 @@ type LocationMessage struct {
 	Latitude  float64
 	Longitude float64
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -262,14 +262,14 @@ func (m *LocationMessage) MarshalJSON() ([]byte, error) {
 		Address:    m.Address,
 		Latitude:   m.Latitude,
 		Longitude:  m.Longitude,
-		QuickReply: m.quickReplyitems,
+		QuickReply: m.quickReplyItems,
 		Sender:     m.sender,
 	})
 }
 
 // WithQuickReplies method of LocationMessage
 func (m *LocationMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -292,7 +292,7 @@ type StickerMessage struct {
 	StickerResourceType StickerResourceType
 	Keywords            []string
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -312,14 +312,14 @@ func (m *StickerMessage) MarshalJSON() ([]byte, error) {
 		StickerID:           m.StickerID,
 		StickerResourceType: m.StickerResourceType,
 		Keywords:            m.Keywords,
-		QuickReply:          m.quickReplyitems,
+		QuickReply:          m.quickReplyItems,
 		Sender:              m.sender,
 	})
 }
 
 // WithQuickReplies method of StickerMessage
 func (m *StickerMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -339,7 +339,7 @@ type TemplateMessage struct {
 	AltText  string
 	Template Template
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -355,14 +355,14 @@ func (m *TemplateMessage) MarshalJSON() ([]byte, error) {
 		Type:       MessageTypeTemplate,
 		AltText:    m.AltText,
 		Template:   m.Template,
-		QuickReply: m.quickReplyitems,
+		QuickReply: m.quickReplyItems,
 		Sender:     m.sender,
 	})
 }
 
 // WithQuickReplies method of TemplateMessage
 func (m *TemplateMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -385,7 +385,7 @@ type ImagemapMessage struct {
 	Actions  []ImagemapAction
 	Video    *ImagemapVideo
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -407,7 +407,7 @@ func (m *ImagemapMessage) MarshalJSON() ([]byte, error) {
 		BaseSize:   m.BaseSize,
 		Actions:    m.Actions,
 		Video:      m.Video,
-		QuickReply: m.quickReplyitems,
+		QuickReply: m.quickReplyItems,
 		Sender:     m.sender,
 	})
 }
@@ -420,7 +420,7 @@ func (m *ImagemapMessage) WithVideo(video *ImagemapVideo) *ImagemapMessage {
 
 // WithQuickReplies method of ImagemapMessage
 func (m *ImagemapMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 
@@ -440,7 +440,7 @@ type FlexMessage struct {
 	AltText  string
 	Contents FlexContainer
 
-	quickReplyitems *QuickReplyItems
+	quickReplyItems *QuickReplyItems
 	sender          *Sender
 }
 
@@ -456,14 +456,14 @@ func (m *FlexMessage) MarshalJSON() ([]byte, error) {
 		Type:       MessageTypeFlex,
 		AltText:    m.AltText,
 		Contents:   m.Contents,
-		QuickReply: m.quickReplyitems,
+		QuickReply: m.quickReplyItems,
 		Sender:     m.sender,
 	})
 }
 
 // WithQuickReplies method of FlexMessage
 func (m *FlexMessage) WithQuickReplies(items *QuickReplyItems) SendingMessage {
-	m.quickReplyitems = items
+	m.quickReplyItems = items
 	return m
 }
 

--- a/linebot/message.go
+++ b/linebot/message.go
@@ -135,7 +135,7 @@ func (m *ImageMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of ImageMessage
-func (m *ImageMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *ImageMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 
@@ -179,7 +179,7 @@ func (m *VideoMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of VideoMessage
-func (m *VideoMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *VideoMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 
@@ -223,7 +223,7 @@ func (m *AudioMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of AudioMessage
-func (m *AudioMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *AudioMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 
@@ -280,7 +280,7 @@ func (m *LocationMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of LocationMessage
-func (m *LocationMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *LocationMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 
@@ -330,7 +330,7 @@ func (m *StickerMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of StickerMessage
-func (m *StickerMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *StickerMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 
@@ -373,7 +373,7 @@ func (m *TemplateMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of TemplateMessage
-func (m *TemplateMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *TemplateMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 
@@ -431,7 +431,7 @@ func (m *ImagemapMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of ImagemapMessage
-func (m *ImagemapMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *ImagemapMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 
@@ -474,7 +474,7 @@ func (m *FlexMessage) WithSender(sender *Sender) SendingMessage {
 }
 
 // AddEmoji method of FlexMessage
-func (m *FlexMessage) AddEmoji(emoji *Emoji) SendingMessage {
+func (m *FlexMessage) AddEmoji(*Emoji) SendingMessage {
 	return m
 }
 

--- a/linebot/oauth.go
+++ b/linebot/oauth.go
@@ -52,7 +52,7 @@ func (call *IssueAccessTokenCall) Do() (*AccessTokenResponse, error) {
 	vs.Set("client_secret", call.channelSecret)
 	body := strings.NewReader(vs.Encode())
 
-	res, err := call.c.postform(call.ctx, APIEndpointIssueAccessToken, body)
+	res, err := call.c.postForm(call.ctx, APIEndpointIssueAccessToken, body)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (call *RevokeAccessTokenCall) Do() (*BasicResponse, error) {
 	vs.Set("access_token", call.accessToken)
 	body := strings.NewReader(vs.Encode())
 
-	res, err := call.c.postform(call.ctx, APIEndpointRevokeAccessToken, body)
+	res, err := call.c.postForm(call.ctx, APIEndpointRevokeAccessToken, body)
 	if err != nil {
 		return nil, err
 	}

--- a/linebot/oauth2.go
+++ b/linebot/oauth2.go
@@ -52,7 +52,7 @@ func (call *IssueAccessTokenV2Call) Do() (*AccessTokenResponse, error) {
 	vs.Set("client_assertion", call.clientAssertion)
 	body := strings.NewReader(vs.Encode())
 
-	res, err := call.c.postform(call.ctx, APIEndpointIssueAccessTokenV2, body)
+	res, err := call.c.postForm(call.ctx, APIEndpointIssueAccessTokenV2, body)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (call *GetAccessTokensV2Call) Do() (*AccessTokensResponse, error) {
 
 	res, err := call.c.get(call.ctx, call.c.endpointBase, APIEndpointGetAccessTokensV2, vs)
 	//	body := strings.NewReader(vs.Encode())
-	//	res, err := call.c.postform(call.ctx, APIEndpointGetAccessTokensV2, body)
+	//	res, err := call.c.postForm(call.ctx, APIEndpointGetAccessTokensV2, body)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (call *RevokeAccessTokenV2Call) Do() (*BasicResponse, error) {
 	vs.Set("client_secret", call.channelSecret)
 	body := strings.NewReader(vs.Encode())
 
-	res, err := call.c.postform(call.ctx, APIEndpointRevokeAccessTokenV2, body)
+	res, err := call.c.postForm(call.ctx, APIEndpointRevokeAccessTokenV2, body)
 	if err != nil {
 		return nil, err
 	}

--- a/linebot/raw_test.go
+++ b/linebot/raw_test.go
@@ -180,10 +180,10 @@ func runTestCase(t *testing.T, tc testcase) {
 		t.Fatal(err)
 	}
 	res, err := tc.Call(client)
-	defer res.Body.Close()
 	if err != nil {
 		t.Error(err)
 	}
+	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/linebot/response.go
+++ b/linebot/response.go
@@ -621,7 +621,7 @@ func decodeToAccessTokensResponse(res *http.Response) (*AccessTokensResponse, er
 	return &result, nil
 }
 
-func decodeToTestWebhookResponsee(res *http.Response) (*TestWebhookResponse, error) {
+func decodeToTestWebhookResponse(res *http.Response) (*TestWebhookResponse, error) {
 	if err := checkResponse(res); err != nil {
 		return nil, err
 	}

--- a/linebot/richmenu.go
+++ b/linebot/richmenu.go
@@ -54,8 +54,8 @@ type RichMenuAction struct {
 	Type        RichMenuActionType `json:"type"`
 	URI         string             `json:"uri,omitempty"`
 	Text        string             `json:"text,omitempty"`
-	DisplayText string             `json:"displayText,omitemtpy"`
-	Label       string             `json:"label,omitemtpy"`
+	DisplayText string             `json:"displayText,omitempty"`
+	Label       string             `json:"label,omitempty"`
 	Data        string             `json:"data,omitempty"`
 	Mode        string             `json:"mode,omitempty"`
 	Initial     string             `json:"initial,omitempty"`

--- a/linebot/send_message_test.go
+++ b/linebot/send_message_test.go
@@ -1865,7 +1865,7 @@ func TestMessagesWithRetryKey(t *testing.T) {
 		"U0cc15697597f61dd8b01cea8b027050e",
 		"U38ecbecfade326557b6971140741a4a6",
 	}
-	var msgUUIDs string = "123e4567-e89b-12d3-a456-426655440002"
+	var msgUUIDs = "123e4567-e89b-12d3-a456-426655440002"
 
 	type want struct {
 		RequestBody []byte

--- a/linebot/webhook.go
+++ b/linebot/webhook.go
@@ -170,5 +170,5 @@ func (call *TestWebhook) Do() (*TestWebhookResponse, error) {
 		return nil, err
 	}
 	defer closeResponse(res)
-	return decodeToTestWebhookResponsee(res)
+	return decodeToTestWebhookResponse(res)
 }

--- a/linebot/webhook_test.go
+++ b/linebot/webhook_test.go
@@ -1073,7 +1073,7 @@ func TestParseRequest(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		req.Header.Set("X-Line-Signature", "invalidsignatue")
+		req.Header.Set("X-Line-Signature", "invalidSignature")
 		res, err := httpClient.Do(req)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
### Overview
See commit.

1. [58ea1fe](https://github.com/line/line-bot-sdk-go/commit/58ea1feff0fef4bbba8bfae97e6370beb54b4f5d) Fix the wrong constant type ⚠️
2. [4e4cc43](https://github.com/line/line-bot-sdk-go/commit/4e4cc4337957f13e749b34751f5a6ece15feb4d6) Typo correction
3. [b89478c](https://github.com/line/line-bot-sdk-go/commit/b89478cc1935ec460f5e43e57fe370e49199f436) Cleanup code
4. [53161b7](https://github.com/line/line-bot-sdk-go/commit/53161b7b7d145995ae87d88ba630217f2b7aa645) Consider nil ⚠️
5. [f670bb4](https://github.com/line/line-bot-sdk-go/commit/f670bb42bf40f10b78c67103ae12e3f94272fe91) Fixed to the correct tag name(`omitemtpy` -> `omitempty`) ⚠️

### Other
Typo errors in public names have not been corrected.
I'd like to fix the public name as well ... :(