### PR TITLE
Update README.md's build badge to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LINE Messaging API SDK for Go
 
-[![Build Status](https://travis-ci.org/line/line-bot-sdk-go.svg?branch=master)](https://travis-ci.org/line/line-bot-sdk-go)
+[![Build Status](https://github.com/line/line-bot-sdk-go/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/line/line-bot-sdk-go/actions)
 [![codecov](https://codecov.io/gh/line/line-bot-sdk-go/branch/master/graph/badge.svg)](https://codecov.io/gh/line/line-bot-sdk-go)
 [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/line/line-bot-sdk-go/linebot)
 [![Go Report Card](https://goreportcard.com/badge/github.com/line/line-bot-sdk-go)](https://goreportcard.com/report/github.com/line/line-bot-sdk-go)


### PR DESCRIPTION
Replace Travis CI build badge with GitHub Actions build badge.