### PR TITLE
Use t.Fatal instead of t.Error on checking nil response

### DIFF
--- a/linebot/httphandler/httphandler_test.go
+++ b/linebot/httphandler/httphandler_test.go
@@ -99,7 +99,7 @@ func TestWebhookHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		if res == nil {
-			t.Error("response is nil")
+			t.Fatal("response is nil")
 		}
 		if res.StatusCode != http.StatusOK {
 			t.Errorf("status: %d", res.StatusCode)
@@ -127,7 +127,7 @@ func TestWebhookHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		if res == nil {
-			t.Error("response is nil")
+			t.Fatal("response is nil")
 		}
 		if res.StatusCode != 400 {
 			t.Errorf("status: %d", 400)

--- a/linebot/webhook_test.go
+++ b/linebot/webhook_test.go
@@ -1251,7 +1251,7 @@ func TestParseRequest(t *testing.T) {
 			t.Fatal(err)
 		}
 		if res == nil {
-			t.Error("response is nil")
+			t.Fatal("response is nil")
 		}
 		if res.StatusCode != http.StatusOK {
 			t.Errorf("status: %d", res.StatusCode)


### PR DESCRIPTION
Tests can cause nil pointer dereference if response is `nil` because it
uses `t.Error` that's just report an error to test output. Fixes by
using `t.Fatal` to stop immediately when the `res` is `nil`