### PR TITLE
Messaging API Update - November 2021 - Support text enter sticker msg.

### DIFF
--- a/linebot/event.go
+++ b/linebot/event.go
@@ -183,10 +183,10 @@ const (
 	StickerResourceTypeAnimation      StickerResourceType = "ANIMATION"
 	StickerResourceTypeSound          StickerResourceType = "SOUND"
 	StickerResourceTypeAnimationSound StickerResourceType = "ANIMATION_SOUND"
-	StickerResourceTypePerStickerText StickerResourceType = "PER_STICKER_TEXT"
+	StickerResourceTypePerStickerText StickerResourceType = "MESSAGE"
 	StickerResourceTypePopup          StickerResourceType = "POPUP"
 	StickerResourceTypePopupSound     StickerResourceType = "POPUP_SOUND"
-	StickerResourceTypeNameText       StickerResourceType = "NAME_TEXT"
+	StickerResourceTypeNameText       StickerResourceType = "CUSTOM"
 )
 
 // Event type

--- a/linebot/webhook_test.go
+++ b/linebot/webhook_test.go
@@ -249,7 +249,7 @@ var webhookTestRequestBody = `{
                 "type": "sticker",
                 "packageId": "20",
                 "stickerId": "3",
-                "stickerResourceType": "PER_STICKER_TEXT",
+                "stickerResourceType": "MESSAGE",
 				"keywords": ["cony","sally","Staring","hi","whatsup","line","howdy","HEY","Peeking","wave","peek","Hello","yo","greetings"]
             }
         },


### PR DESCRIPTION
Fix #295 

- You can now retrieve the text entered by the user in a message sticker
- You can now retrieve up to 1000 user IDs of friends

Reference: https://developers.line.biz/en/news/2021/11/09/messaging-api-update/