### PR TITLE
Fixed #298 sticker text issue, add text parameter.

### DIFF
--- a/linebot/event.go
+++ b/linebot/event.go
@@ -405,6 +405,7 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 			StickerID:           m.StickerID,
 			StickerResourceType: m.StickerResourceType,
 			Keywords:            m.Keywords,
+			Text:                m.Text,
 		}
 	}
 	return json.Marshal(&raw)
@@ -472,6 +473,7 @@ func (e *Event) UnmarshalJSON(body []byte) (err error) {
 				StickerID:           rawEvent.Message.StickerID,
 				StickerResourceType: rawEvent.Message.StickerResourceType,
 				Keywords:            rawEvent.Message.Keywords,
+				Text:                rawEvent.Message.Text,
 			}
 		}
 	case EventTypePostback:

--- a/linebot/message.go
+++ b/linebot/message.go
@@ -309,6 +309,7 @@ type StickerMessage struct {
 	StickerID           string
 	StickerResourceType StickerResourceType
 	Keywords            []string
+	Text                string
 
 	quickReplyItems *QuickReplyItems
 	sender          *Sender
@@ -325,6 +326,7 @@ func (m *StickerMessage) MarshalJSON() ([]byte, error) {
 		Keywords            []string            `json:"keywords,omitempty"`
 		QuickReply          *QuickReplyItems    `json:"quickReply,omitempty"`
 		Sender              *Sender             `json:"sender,omitempty"`
+		Text                string              `json:"text,omitempty"`
 	}{
 		Type:                m.messageType,
 		PackageID:           m.PackageID,
@@ -333,6 +335,7 @@ func (m *StickerMessage) MarshalJSON() ([]byte, error) {
 		Keywords:            m.Keywords,
 		QuickReply:          m.quickReplyItems,
 		Sender:              m.sender,
+		Text:                m.Text,
 	})
 }
 


### PR DESCRIPTION
Fixed PR #298 could not parse enter text "text" from sticker directly.
Original  structure Sticker doesn't have the variable. 

```

type StickerMessage struct {
	ID                  string
	PackageID           string
	StickerID           string
	StickerResourceType StickerResourceType
	Keywords            []string

	quickReplyItems *QuickReplyItems
	sender          *Sender
	messageType     MessageType
}
```
