### PR TITLE
Make the X-Line-Signature header case-insensitive when handling in server side.

### DIFF
--- a/linebot/webhook.go
+++ b/linebot/webhook.go
@@ -38,7 +38,7 @@ func ParseRequest(channelSecret string, r *http.Request) ([]*Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !validateSignature(channelSecret, r.Header.Get("X-Line-Signature"), body) {
+	if !validateSignature(channelSecret, r.Header.Get("x-line-signature"), body) {
 		return nil, ErrInvalidSignature
 	}
 


### PR DESCRIPTION
According to https://developers.line.biz/en/reference/messaging-api/#request-headers, It is better to be case-insensitive when handling request headers.