### PR TITLE
Add InputOption for RichMenuAction

### DIFF
--- a/linebot/richmenu.go
+++ b/linebot/richmenu.go
@@ -64,6 +64,7 @@ type RichMenuAction struct {
 	Min             string             `json:"min,omitempty"`
 	RichMenuAliasID string             `json:"richMenuAliasId,omitempty"`
 	InputOption     InputOption        `json:"inputOption,omitempty"`
+	FillInText      string             `json:"fillInText,omitempty"`
 }
 
 // AreaDetail type for areas array

--- a/linebot/richmenu.go
+++ b/linebot/richmenu.go
@@ -63,6 +63,7 @@ type RichMenuAction struct {
 	Max             string             `json:"max,omitempty"`
 	Min             string             `json:"min,omitempty"`
 	RichMenuAliasID string             `json:"richMenuAliasId,omitempty"`
+	InputOption     InputOption        `json:"inputOption,omitempty"`
 }
 
 // AreaDetail type for areas array


### PR DESCRIPTION
It seems that the InoutOption of PostbackAction is missing from RichMenuAction.

official doc: https://developers.line.biz/ja/reference/messaging-api/#postback-action
ref: https://github.com/line/line-bot-sdk-go/blob/master/linebot/actions.go#L113

I'm not very experienced, so please let me know if there's anything amiss or if I've overlooked something.