### PR TITLE
Support Go 1.21 and drop 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         go:
-        - '1.19'
-        - '1.19.11'
         - '1.20'
-        - '1.20.6'
+        - '1.20.10'
+        - '1.21'
+        - '1.21.3'
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the official API documentation for more information.
 
 ## Requirements
 
-This library requires Go 1.11 or later.
+This library requires Go 1.20 or later.
 
 ## Installation ##
 
@@ -29,17 +29,17 @@ $ go get -u github.com/line/line-bot-sdk-go/v7/linebot
 ## Import all packages in your code ##
 ```go
 import (
-    "github.com/line/line-bot-sdk-go/v7/linebot"
-    "github.com/line/line-bot-sdk-go/v7/linebot/channel_access_token"
-    "github.com/line/line-bot-sdk-go/v7/linebot/httphandler"
-    "github.com/line/line-bot-sdk-go/v7/linebot/insight"
-    "github.com/line/line-bot-sdk-go/v7/linebot/liff"
-    "github.com/line/line-bot-sdk-go/v7/linebot/manage_audience"
-    "github.com/line/line-bot-sdk-go/v7/linebot/messaging_api"
-    "github.com/line/line-bot-sdk-go/v7/linebot/module"
-    "github.com/line/line-bot-sdk-go/v7/linebot/module_attach"
-    "github.com/line/line-bot-sdk-go/v7/linebot/shop"
-    "github.com/line/line-bot-sdk-go/v7/linebot/webhook"
+	"github.com/line/line-bot-sdk-go/v7/linebot"
+	"github.com/line/line-bot-sdk-go/v7/linebot/channel_access_token"
+	"github.com/line/line-bot-sdk-go/v7/linebot/httphandler"
+	"github.com/line/line-bot-sdk-go/v7/linebot/insight"
+	"github.com/line/line-bot-sdk-go/v7/linebot/liff"
+	"github.com/line/line-bot-sdk-go/v7/linebot/manage_audience"
+	"github.com/line/line-bot-sdk-go/v7/linebot/messaging_api"
+	"github.com/line/line-bot-sdk-go/v7/linebot/module"
+	"github.com/line/line-bot-sdk-go/v7/linebot/module_attach"
+	"github.com/line/line-bot-sdk-go/v7/linebot/shop"
+	"github.com/line/line-bot-sdk-go/v7/linebot/webhook"
 )
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/line/line-bot-sdk-go/v7
 
-go 1.19
+go 1.20


### PR DESCRIPTION
I found 1.19 was EOL and 1.21 was released : https://endoflife.date/go