### PR TITLE
Update linebot/version.go forcibly when release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: On Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-version-file:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Install gobump
+        run: go install github.com/x-motemen/gobump/cmd/gobump@latest
+
+      - name: Echo the release tag
+        run: |
+          echo "The release tag is: ${{ github.event.release.tag_name }}"
+
+      - name: Checkout master branch
+        uses: actions/checkout@v4
+        with:
+          ref: 'master'
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Commit and push linebot/version.go to master
+        run: |
+          VERSION=${{ github.event.release.tag_name }}
+          VERSION=${VERSION#v}
+          gobump set $VERSION -w -v linebot
+          git add linebot/version.go
+          git commit -m "Update version.go with tag information for ${{ github.event.release.tag_name }}"
+          git push
+
+      - name: Get the latest commit SHA
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Force tag update to the latest commit
+        run: |
+          git tag -fa ${{ github.event.release.tag_name }} -m "Update tag for ${{ github.event.release.tag_name }}" ${{ env.sha }}
+          git push origin ${{ github.event.release.tag_name }} --force


### PR DESCRIPTION
This change adds github workflow to update `linebot/version.go` forcibly with published git tag when release is published.
If it works, we don't have to update the file manually!

Resolve #362 