### PR TITLE
bugfix: int32 is converted to incorrect string

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
@@ -122,6 +122,8 @@ func With{{ classname contains "Blob" ? "Blob" : "" }}Endpoint(endpoint string) 
     strconv.FormatInt(int64({{ param.paramName }}), 10)
     {%- elseif param.isBoolean -%}
     strconv.FormatBool({{ param.paramName }})
+    {%- elseif param.isString -%}
+    {{ param.paramName }}
     {%- else -%}
     string({{ param.paramName }})
     {%- endif -%}

--- a/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
@@ -118,6 +118,8 @@ func With{{ classname contains "Blob" ? "Blob" : "" }}Endpoint(endpoint string) 
 {% macro stringify(param) -%}
     {%- if param.isLong -%}
     strconv.FormatInt({{ param.paramName }}, 10)
+    {%- elseif param.isInteger -%}
+    strconv.FormatInt(int64({{ param.paramName }}), 10)
     {%- elseif param.isBoolean -%}
     strconv.FormatBool({{ param.paramName }})
     {%- else -%}
@@ -193,7 +195,7 @@ func (client *{{ classname }}) {{ op.operationId }}WithHttpInfo(
 ) (*http.Response, {% if op.isResponseFile %}*http.Response{% elseif op.returnType %}*{{ op.returnType }}{% else %}struct{}{% endif %}, error) {
     path := "{{ op.path }}"
     {% for pp in op.pathParams %}
-    path = strings.Replace(path, "{{ "{" }}{{ pp.paramName }}{{ "}" }}", {% if pp.isInteger or pp.isLong %}strconv.FormatInt({{ pp.paramName }}, 10){% else %}{{ pp.paramName }}{% endif %}, -1)
+    path = strings.Replace(path, "{{ "{" }}{{ pp.paramName }}{{ "}" }}", {{ stringify(pp) }}, -1)
     {% endfor %}
     {% if op.bodyParam != null and op.bodyParam.isFile %}
 	req, err := http.NewRequest(http.Method{{ op.httpMethod }}, client.Url(path), {{ op.bodyParam.paramName }}Reader)

--- a/linebot/channel_access_token/api_channel_access_token.go
+++ b/linebot/channel_access_token/api_channel_access_token.go
@@ -152,8 +152,8 @@ func (client *ChannelAccessTokenAPI) GetsAllValidChannelAccessTokenKeyIdsWithHtt
 	}
 
 	var query url.Values
-	query = url.Values{"clientAssertionType": []string{string(clientAssertionType)}}
-	query = url.Values{"clientAssertion": []string{string(clientAssertion)}}
+	query = url.Values{"clientAssertionType": []string{clientAssertionType}}
+	query = url.Values{"clientAssertion": []string{clientAssertion}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -742,7 +742,7 @@ func (client *ChannelAccessTokenAPI) VerifyChannelTokenByJWTWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"accessToken": []string{string(accessToken)}}
+	query = url.Values{"accessToken": []string{accessToken}}
 
 	req.URL.RawQuery = query.Encode()
 

--- a/linebot/insight/api_insight.go
+++ b/linebot/insight/api_insight.go
@@ -207,7 +207,7 @@ func (client *InsightAPI) GetMessageEventWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"requestId": []string{string(requestId)}}
+	query = url.Values{"requestId": []string{requestId}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -278,7 +278,7 @@ func (client *InsightAPI) GetNumberOfFollowersWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -349,7 +349,7 @@ func (client *InsightAPI) GetNumberOfMessageDeliveriesWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -436,9 +436,9 @@ func (client *InsightAPI) GetStatisticsPerUnitWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"customAggregationUnit": []string{string(customAggregationUnit)}}
-	query = url.Values{"from": []string{string(from)}}
-	query = url.Values{"to": []string{string(to)}}
+	query = url.Values{"customAggregationUnit": []string{customAggregationUnit}}
+	query = url.Values{"from": []string{from}}
+	query = url.Values{"to": []string{to}}
 
 	req.URL.RawQuery = query.Encode()
 

--- a/linebot/manage_audience/api_manage_audience.go
+++ b/linebot/manage_audience/api_manage_audience.go
@@ -727,7 +727,7 @@ func (client *ManageAudienceAPI) GetAudienceGroupsWithHttpInfo(
 
 	var query url.Values
 	query = url.Values{"page": []string{strconv.FormatInt(page, 10)}}
-	query = url.Values{"description": []string{string(description)}}
+	query = url.Values{"description": []string{description}}
 	query = url.Values{"status": []string{string(status)}}
 	query = url.Values{"size": []string{strconv.FormatInt(size, 10)}}
 	query = url.Values{"includesExternalPublicGroups": []string{strconv.FormatBool(includesExternalPublicGroups)}}

--- a/linebot/manage_audience/api_manage_audience_blob.go
+++ b/linebot/manage_audience/api_manage_audience_blob.go
@@ -172,7 +172,7 @@ func (client *ManageAudienceBlobAPI) AddUserIdsToAudienceWithHttpInfo(
 
 	writer.WriteField("audienceGroupId", strconv.FormatInt(audienceGroupId, 10))
 
-	writer.WriteField("uploadDescription", string(uploadDescription))
+	writer.WriteField("uploadDescription", uploadDescription)
 
 	fileWriter, err := writer.CreateFormFile("file", file.Name())
 	if err != nil {
@@ -274,11 +274,11 @@ func (client *ManageAudienceBlobAPI) CreateAudienceForUploadingUserIdsWithHttpIn
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	writer.WriteField("description", string(description))
+	writer.WriteField("description", description)
 
 	writer.WriteField("isIfaAudience", strconv.FormatBool(isIfaAudience))
 
-	writer.WriteField("uploadDescription", string(uploadDescription))
+	writer.WriteField("uploadDescription", uploadDescription)
 
 	fileWriter, err := writer.CreateFormFile("file", file.Name())
 	if err != nil {

--- a/linebot/messaging_api/api_messaging_api.go
+++ b/linebot/messaging_api/api_messaging_api.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/line/line-bot-sdk-go/v8/linebot"
@@ -235,7 +236,7 @@ func (client *MessagingApiAPI) BroadcastWithHttpInfo(
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
-	req.Header.Set("X-Line-Retry-Key", string(xLineRetryKey))
+	req.Header.Set("X-Line-Retry-Key", xLineRetryKey)
 
 	res, err := client.Do(req)
 
@@ -617,7 +618,7 @@ func (client *MessagingApiAPI) GetAdPhoneMessageStatisticsWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -696,8 +697,8 @@ func (client *MessagingApiAPI) GetAggregationUnitNameListWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"limit": []string{string(limit)}}
-	query = url.Values{"start": []string{string(start)}}
+	query = url.Values{"limit": []string{limit}}
+	query = url.Values{"start": []string{start}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -935,8 +936,8 @@ func (client *MessagingApiAPI) GetFollowersWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"start": []string{string(start)}}
-	query = url.Values{"limit": []string{string(limit)}}
+	query = url.Values{"start": []string{start}}
+	query = url.Values{"limit": []string{strconv.FormatInt(int64(limit), 10)}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -1163,7 +1164,7 @@ func (client *MessagingApiAPI) GetGroupMembersIdsWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"start": []string{string(start)}}
+	query = url.Values{"start": []string{start}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -1408,7 +1409,7 @@ func (client *MessagingApiAPI) GetNarrowcastProgressWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"requestId": []string{string(requestId)}}
+	query = url.Values{"requestId": []string{requestId}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -1479,7 +1480,7 @@ func (client *MessagingApiAPI) GetNumberOfSentBroadcastMessagesWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -1550,7 +1551,7 @@ func (client *MessagingApiAPI) GetNumberOfSentMulticastMessagesWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -1621,7 +1622,7 @@ func (client *MessagingApiAPI) GetNumberOfSentPushMessagesWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -1692,7 +1693,7 @@ func (client *MessagingApiAPI) GetNumberOfSentReplyMessagesWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -1763,7 +1764,7 @@ func (client *MessagingApiAPI) GetPNPMessageStatisticsWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"date": []string{string(date)}}
+	query = url.Values{"date": []string{date}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -2091,7 +2092,7 @@ func (client *MessagingApiAPI) GetRichMenuBatchProgressWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"requestId": []string{string(requestId)}}
+	query = url.Values{"requestId": []string{requestId}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -2439,7 +2440,7 @@ func (client *MessagingApiAPI) GetRoomMembersIdsWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"start": []string{string(start)}}
+	query = url.Values{"start": []string{start}}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -2977,7 +2978,7 @@ func (client *MessagingApiAPI) MulticastWithHttpInfo(
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
-	req.Header.Set("X-Line-Retry-Key", string(xLineRetryKey))
+	req.Header.Set("X-Line-Retry-Key", xLineRetryKey)
 
 	res, err := client.Do(req)
 
@@ -3059,7 +3060,7 @@ func (client *MessagingApiAPI) NarrowcastWithHttpInfo(
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
-	req.Header.Set("X-Line-Retry-Key", string(xLineRetryKey))
+	req.Header.Set("X-Line-Retry-Key", xLineRetryKey)
 
 	res, err := client.Do(req)
 
@@ -3141,7 +3142,7 @@ func (client *MessagingApiAPI) PushMessageWithHttpInfo(
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
-	req.Header.Set("X-Line-Retry-Key", string(xLineRetryKey))
+	req.Header.Set("X-Line-Retry-Key", xLineRetryKey)
 
 	res, err := client.Do(req)
 
@@ -3223,7 +3224,7 @@ func (client *MessagingApiAPI) PushMessagesByPhoneWithHttpInfo(
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
-	req.Header.Set("X-Line-Delivery-Tag", string(xLineDeliveryTag))
+	req.Header.Set("X-Line-Delivery-Tag", xLineDeliveryTag)
 
 	res, err := client.Do(req)
 

--- a/linebot/messaging_api/tests/handwritten/api_GetFollowers_test.go
+++ b/linebot/messaging_api/tests/handwritten/api_GetFollowers_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/line/line-bot-sdk-go/v8/linebot/messaging_api"
+)
+
+func TestGetFollowers_ItShouldCorrectlyPassLimitQueryParameter(t *testing.T) {
+	expectedLimit := "1000"
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotLimit := r.URL.Query().Get("limit")
+			if gotLimit != expectedLimit {
+				w.Header().Set("TEST-ERROR", fmt.Sprintf("incorrect limit being sent from client. expected %s, got %s", expectedLimit, gotLimit))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(messaging_api.GetFollowersResponse{UserIds: []string{}, Next: "abcdef"})
+		}),
+	)
+	client, err := messaging_api.NewMessagingApiAPI(
+		"channelToken",
+		messaging_api.WithEndpoint(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	resp, _, err := client.GetFollowersWithHttpInfo("", 1000)
+	if err != nil {
+		t.Fatalf("Failed to get followers: %v", err)
+	}
+	log.Printf("Got response: %v", resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Not getting 200 response back: %s", resp.Header.Get("TEST-ERROR"))
+	}
+}

--- a/linebot/module/api_line_module.go
+++ b/linebot/module/api_line_module.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/line/line-bot-sdk-go/v8/linebot"
@@ -307,8 +308,8 @@ func (client *LineModuleAPI) GetModulesWithHttpInfo(
 	}
 
 	var query url.Values
-	query = url.Values{"start": []string{string(start)}}
-	query = url.Values{"limit": []string{string(limit)}}
+	query = url.Values{"start": []string{start}}
+	query = url.Values{"limit": []string{strconv.FormatInt(int64(limit), 10)}}
 
 	req.URL.RawQuery = query.Encode()
 


### PR DESCRIPTION
Currently, `stringify` macro in `api.pebble` doesn't handle `int32` Go type properly. It directly uses `string(...)` to convert `int32` to `string` which will generate a UTF-8 character corresponding to the value of int instead. For example, `string(57)` will result in `"9"` instead of `"57"`. This bug makes `MessagingApiAPI.GetFollowers(start string, limit int32)` to be nearly impossible to use.

To fix this, this PR changes add another condition to `stringify` macro for `Integer` type. With this change, it will use `strconv.FormatInteger(int64(...), 10)` instead of `string(...)` which yield a correct string value.

Apart from the bugfix, I also refactor `api.pebble` a bit to re-use `stringify` macro for any place required to use `string` type. And also add another condition to `stringify` macro to not doing an unnecessary string-conversion again for `string` type.