### PR TITLE
refactored error comparison to use errors.Is

### DIFF
--- a/examples/echo_bot/server.go
+++ b/examples/echo_bot/server.go
@@ -41,7 +41,7 @@ func main() {
 		cb, err := webhook.ParseRequest(channelSecret, req)
 		if err != nil {
 			log.Printf("Cannot parse request: %+v\n", err)
-			if err == linebot.ErrInvalidSignature {
+			if errors.Is(err, webhook.ErrInvalidSignature) {
 				w.WriteHeader(400)
 			} else {
 				w.WriteHeader(500)


### PR DESCRIPTION
## Background
We ran the main function of the echo bot included in the SDK in the PR author's environment. I then threw an HTTP request without the x-line-signature HTTP header.

In the webhook.ParseRequest function, it returns ErrInvalidSignature if the x-line-signature header is not present in the request. So the caller should originally return HTTP status code 400. However, in the author's environment, it returned 500. In other words, the error comparison that should have been true was false. The error in the webhook package is now compared to the error returned by the ParseRequest function so that it returns 400, which is what would be expected.

The author is using macOS Ventura 13.6.1, Intel Corei7, Golang 1.20.6.

## Changes
- Updated error comparison from `==` to `errors.Is` in `examples/echo_bot/server.go`.