### PR TITLE
Fix: Correctly handle ErrInvalidSignature comparison

### DIFF
--- a/examples/echo_bot/server.go
+++ b/examples/echo_bot/server.go
@@ -15,12 +15,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 
-	"github.com/line/line-bot-sdk-go/v8/linebot"
 	"github.com/line/line-bot-sdk-go/v8/linebot/messaging_api"
 	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
 )
@@ -41,7 +41,7 @@ func main() {
 		cb, err := webhook.ParseRequest(channelSecret, req)
 		if err != nil {
 			log.Printf("Cannot parse request: %+v\n", err)
-			if err.Error() == linebot.ErrInvalidSignature.Error() {
+			if errors.Is(err, webhook.ErrInvalidSignature) {
 				w.WriteHeader(400)
 			} else {
 				w.WriteHeader(500)

--- a/examples/echo_bot/server.go
+++ b/examples/echo_bot/server.go
@@ -41,7 +41,7 @@ func main() {
 		cb, err := webhook.ParseRequest(channelSecret, req)
 		if err != nil {
 			log.Printf("Cannot parse request: %+v\n", err)
-			if err == linebot.ErrInvalidSignature {
+			if err.Error() == linebot.ErrInvalidSignature.Error() {
 				w.WriteHeader(400)
 			} else {
 				w.WriteHeader(500)

--- a/examples/kitchensink/server.go
+++ b/examples/kitchensink/server.go
@@ -106,7 +106,7 @@ func NewKitchenSink(channelSecret, channelToken, appBaseURL string) (*KitchenSin
 func (app *KitchenSink) Callback(w http.ResponseWriter, r *http.Request) {
 	cb, err := webhook.ParseRequest(app.channelSecret, r)
 	if err != nil {
-		if err == linebot.ErrInvalidSignature {
+		if err.Error() == linebot.ErrInvalidSignature.Error() {
 			w.WriteHeader(400)
 		} else {
 			w.WriteHeader(500)

--- a/examples/kitchensink/server.go
+++ b/examples/kitchensink/server.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -25,7 +26,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/line/line-bot-sdk-go/v8/linebot"
 	"github.com/line/line-bot-sdk-go/v8/linebot/messaging_api"
 	"github.com/line/line-bot-sdk-go/v8/linebot/webhook"
 )
@@ -106,7 +106,7 @@ func NewKitchenSink(channelSecret, channelToken, appBaseURL string) (*KitchenSin
 func (app *KitchenSink) Callback(w http.ResponseWriter, r *http.Request) {
 	cb, err := webhook.ParseRequest(app.channelSecret, r)
 	if err != nil {
-		if err.Error() == linebot.ErrInvalidSignature.Error() {
+		if errors.Is(err, webhook.ErrInvalidSignature) {
 			w.WriteHeader(400)
 		} else {
 			w.WriteHeader(500)


### PR DESCRIPTION
## Background
While integrating LINE webhook events, I noticed an inconsistency in how errors, specifically ErrInvalidSignature, were being handled. The direct comparison of errors using == does not effectively catch ErrInvalidSignature due to the way Go's error interface works. This led to improper HTTP status codes being returned, affecting the error feedback mechanism.

## Changes Made
This PR addresses the issue by updating the error comparison logic in both echo_bot and kitchensink examples. Instead of directly comparing error interfaces, the changes involve comparing the error messages:
In echo_bot/server.go and kitchensink/server.go, modified the conditional checks from if err == linebot.ErrInvalidSignature to if err.Error() == linebot.ErrInvalidSignature.Error(). This ensures that the error comparison is based on the error message string, which is a more reliable method for this scenario.

By the way,I have tried using errors.Is(err, linebot.ErrInvalidSignature)

But still can't work

## Version
go version go1.21.3 darwin/arm64

