### PR TITLE
Support Go 1.22 and drop 1.20

### DIFF
--- a/.github/workflows/generated-code.yml
+++ b/.github/workflows/generated-code.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,9 @@ jobs:
     strategy:
       matrix:
         go:
-        - '1.20'
-        - '1.20.10'
         - '1.21'
         - '1.21.3'
+        - '1.22'
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - name: Install gobump
         run: go install github.com/x-motemen/gobump/cmd/gobump@latest

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the official API documentation for more information.
 
 ## Requirements
 
-This library requires Go 1.20 or later.
+This library requires Go 1.21 or later.
 
 ## Installation ##
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/line/line-bot-sdk-go/v8
 
-go 1.20
+go 1.21


### PR DESCRIPTION
1.20 got EOL on 2024-02-06(https://endoflife.date/go)