### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/line/line-bot-sdk-go/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/line/line-bot-sdk-go/actions)
 [![codecov](https://codecov.io/gh/line/line-bot-sdk-go/branch/master/graph/badge.svg)](https://codecov.io/gh/line/line-bot-sdk-go)
-[![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/line/line-bot-sdk-go/linebot)
+[![Go Reference](https://pkg.go.dev/badge/github.com/line/line-bot-sdk-go/v8/linebot.svg)](https://pkg.go.dev/github.com/line/line-bot-sdk-go/v8/linebot)
 [![Go Report Card](https://goreportcard.com/badge/github.com/line/line-bot-sdk-go)](https://goreportcard.com/report/github.com/line/line-bot-sdk-go)
 
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ bot.PushMessage(
 		To: "U.......",
 		Messages: []messaging_api.MessageInterface{
 			messaging_api.TextMessage{
-				Text: replyMessage,
+				Text: pushMessage,
 			},
 		},
 	},
-	nil, // x-line-retry-key
+	"", // x-line-retry-key
 )
 ```
 


### PR DESCRIPTION
- Fix PushMessage example.
  - replyMessage -> pushMessage.
  - x-line-retry-key is string.
- Fix pkg.go.dev badge.
  - Fix to v8.
  - Use "https://pkg.go.dev/badge/".