### PR TITLE
Fix bug: integer cannot be null

### DIFF
--- a/generator/src/main/java/line/bot/generator/pebble/IsOmitEmptyFunction.java
+++ b/generator/src/main/java/line/bot/generator/pebble/IsOmitEmptyFunction.java
@@ -38,7 +38,7 @@ public class IsOmitEmptyFunction implements Function {
             // such as imageBackgroundColor in ButtonsTemplate.
             return true;
         }
-        if (var.isInteger && hasMinimumValueGreaterThanZero(var.minimum)) {
+        if (var.isInteger && isGreaterThanZero(var.minimum)) {
             // For optional integer types with a minimum value greater than 0,
             // it's acceptable to treat 0 as a null value
             return true;
@@ -49,7 +49,7 @@ public class IsOmitEmptyFunction implements Function {
         return true;
     }
 
-    private boolean hasMinimumValueGreaterThanZero(String minValue) {
-        return minValue != null && Integer.parseInt(minValue) > 0;
+    private boolean isGreaterThanZero(String val) {
+        return val != null && Integer.parseInt(val) > 0;
     }
 }

--- a/generator/src/main/java/line/bot/generator/pebble/IsOmitEmptyFunction.java
+++ b/generator/src/main/java/line/bot/generator/pebble/IsOmitEmptyFunction.java
@@ -38,9 +38,18 @@ public class IsOmitEmptyFunction implements Function {
             // such as imageBackgroundColor in ButtonsTemplate.
             return true;
         }
+        if (var.isInteger && hasMinimumValueGreaterThanZero(var.minimum)) {
+            // For optional integer types with a minimum value greater than 0,
+            // it's acceptable to treat 0 as a null value
+            return true;
+        }
         if (var.isPrimitiveType) {
             return false;
         }
         return true;
+    }
+
+    private boolean hasMinimumValueGreaterThanZero(String minValue) {
+        return minValue != null && Integer.parseInt(minValue) > 0;
     }
 }

--- a/linebot/messaging_api/model_limit.go
+++ b/linebot/messaging_api/model_limit.go
@@ -28,7 +28,7 @@ type Limit struct {
 	 * The maximum number of narrowcast messages to send. Use this parameter to limit the number of narrowcast messages sent. The recipients will be chosen at random.
 	 * minimum: 1
 	 */
-	Max int32 `json:"max"`
+	Max int32 `json:"max,omitempty"`
 
 	/**
 	 * If true, the message will be sent within the maximum number of deliverable messages. The default value is `false`.  Targets will be selected at random.

--- a/linebot/messaging_api/model_show_loading_animation_request.go
+++ b/linebot/messaging_api/model_show_loading_animation_request.go
@@ -34,5 +34,5 @@ type ShowLoadingAnimationRequest struct {
 	 * minimum: 5
 	 * maximum: 60
 	 */
-	LoadingSeconds int32 `json:"loadingSeconds"`
+	LoadingSeconds int32 `json:"loadingSeconds,omitempty"`
 }


### PR DESCRIPTION
## Changes

This resolve https://github.com/line/line-bot-sdk-go/issues/466.

## Details
By using the `omitempty` tag on an int field, you can ignore the field during JSON serialization when its value is set to 0. 
This is necessary for endpoints with request bodies that have optional int fields, allowing the request to be made without specifying that field. 
Without the omitempty tag, the request would treat the field as if 0 were explicitly specified.

However, this setting should be limited to fields where specifying a 0 value is not intended. Otherwise, it would prevent the ability to explicitly set a 0 value for those fields.