### PR TITLE
Ignore empty string for query parameter

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
@@ -268,7 +268,13 @@ func (client *{{ classname }}) {{ op.operationId }}WithHttpInfo(
     {% if op.hasQueryParams -%}
 	query := url.Values{}
 	    {% for qp in op.queryParams -%}
+            {% if qp.isString and not qp.required -%}
+    if {{ stringify(qp) }} != "" {
     query.Add("{{ qp.paramName }}", {{ stringify(qp) }})
+    }
+            {% else -%}
+    query.Add("{{ qp.paramName }}", {{ stringify(qp) }})
+            {% endif -%}
 	    {% endfor %}
     req.URL.RawQuery = query.Encode()
     {% endif %}

--- a/linebot/insight/api_insight.go
+++ b/linebot/insight/api_insight.go
@@ -278,7 +278,9 @@ func (client *InsightAPI) GetNumberOfFollowersWithHttpInfo(
 	}
 
 	query := url.Values{}
-	query.Add("date", date)
+	if date != "" {
+		query.Add("date", date)
+	}
 
 	req.URL.RawQuery = query.Encode()
 

--- a/linebot/manage_audience/api_manage_audience.go
+++ b/linebot/manage_audience/api_manage_audience.go
@@ -727,7 +727,9 @@ func (client *ManageAudienceAPI) GetAudienceGroupsWithHttpInfo(
 
 	query := url.Values{}
 	query.Add("page", strconv.FormatInt(page, 10))
-	query.Add("description", description)
+	if description != "" {
+		query.Add("description", description)
+	}
 	query.Add("status", string(status))
 	query.Add("size", strconv.FormatInt(size, 10))
 	query.Add("includesExternalPublicGroups", strconv.FormatBool(includesExternalPublicGroups))

--- a/linebot/messaging_api/api_messaging_api.go
+++ b/linebot/messaging_api/api_messaging_api.go
@@ -697,8 +697,12 @@ func (client *MessagingApiAPI) GetAggregationUnitNameListWithHttpInfo(
 	}
 
 	query := url.Values{}
-	query.Add("limit", limit)
-	query.Add("start", start)
+	if limit != "" {
+		query.Add("limit", limit)
+	}
+	if start != "" {
+		query.Add("start", start)
+	}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -936,7 +940,9 @@ func (client *MessagingApiAPI) GetFollowersWithHttpInfo(
 	}
 
 	query := url.Values{}
-	query.Add("start", start)
+	if start != "" {
+		query.Add("start", start)
+	}
 	query.Add("limit", strconv.FormatInt(int64(limit), 10))
 
 	req.URL.RawQuery = query.Encode()
@@ -1164,7 +1170,9 @@ func (client *MessagingApiAPI) GetGroupMembersIdsWithHttpInfo(
 	}
 
 	query := url.Values{}
-	query.Add("start", start)
+	if start != "" {
+		query.Add("start", start)
+	}
 
 	req.URL.RawQuery = query.Encode()
 
@@ -2561,7 +2569,9 @@ func (client *MessagingApiAPI) GetRoomMembersIdsWithHttpInfo(
 	}
 
 	query := url.Values{}
-	query.Add("start", start)
+	if start != "" {
+		query.Add("start", start)
+	}
 
 	req.URL.RawQuery = query.Encode()
 

--- a/linebot/module/api_line_module.go
+++ b/linebot/module/api_line_module.go
@@ -308,7 +308,9 @@ func (client *LineModuleAPI) GetModulesWithHttpInfo(
 	}
 
 	query := url.Values{}
-	query.Add("start", start)
+	if start != "" {
+		query.Add("start", start)
+	}
 	query.Add("limit", strconv.FormatInt(int64(limit), 10))
 
 	req.URL.RawQuery = query.Encode()


### PR DESCRIPTION
This resolves https://github.com/line/line-bot-sdk-go/issues/474.

## Changes
We are customizing SDK code generation to generate code that directly passes arguments to functions, instead of using a request body struct for the API.
As a result, we are unable to use the "omitempty" tag to ignore fields with empty strings.

To address this issue, we will modify the code to exclude optional string fields from url.Values when they are empty.