### PR TITLE
Ignore empty string for optional args

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
@@ -242,10 +242,19 @@ func (client *{{ classname }}) {{ op.operationId }}WithHttpInfo(
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	{% elseif op.hasFormParams %}
 	vs := url.Values{
-    	{% for fp in op.formParams -%}
-	    "{{ fp.baseName }}": []string{ string({{ fp.paramName }}) },
-    	{% endfor %}
-	}
+        {% for fp in op.formParams -%}
+            {% if not fp.isString or fp.required -%}
+        "{{ fp.baseName }}": []string{ string({{ fp.paramName }}) },
+            {% endif -%}
+        {% endfor %}
+    }
+    {% for fp in op.formParams -%}
+        {% if fp.isString and not fp.required -%}
+    if {{ fp.paramName }} != "" {
+    vs["{{ fp.baseName }}"] = []string{ {{ fp.paramName }} }
+    }
+        {% endif -%}
+    {% endfor -%}
 	buf := vs.Encode()
 	body := bytes.NewBufferString(buf)
 

--- a/linebot/channel_access_token/api_channel_access_token.go
+++ b/linebot/channel_access_token/api_channel_access_token.go
@@ -432,12 +432,21 @@ func (client *ChannelAccessTokenAPI) IssueStatelessChannelTokenWithHttpInfo(
 ) (*http.Response, *IssueStatelessChannelAccessTokenResponse, error) {
 	path := "/oauth2/v3/token"
 
-	vs := url.Values{
-		"grant_type":            []string{string(grantType)},
-		"client_assertion_type": []string{string(clientAssertionType)},
-		"client_assertion":      []string{string(clientAssertion)},
-		"client_id":             []string{string(clientId)},
-		"client_secret":         []string{string(clientSecret)},
+	vs := url.Values{}
+	if grantType != "" {
+		vs["grant_type"] = []string{grantType}
+	}
+	if clientAssertionType != "" {
+		vs["client_assertion_type"] = []string{clientAssertionType}
+	}
+	if clientAssertion != "" {
+		vs["client_assertion"] = []string{clientAssertion}
+	}
+	if clientId != "" {
+		vs["client_id"] = []string{clientId}
+	}
+	if clientSecret != "" {
+		vs["client_secret"] = []string{clientSecret}
 	}
 	buf := vs.Encode()
 	body := bytes.NewBufferString(buf)

--- a/linebot/channel_access_token/api_channel_access_token.go
+++ b/linebot/channel_access_token/api_channel_access_token.go
@@ -432,21 +432,12 @@ func (client *ChannelAccessTokenAPI) IssueStatelessChannelTokenWithHttpInfo(
 ) (*http.Response, *IssueStatelessChannelAccessTokenResponse, error) {
 	path := "/oauth2/v3/token"
 
-	vs := url.Values{}
-	if grantType != "" {
-		vs["grant_type"] = []string{grantType}
-	}
-	if clientAssertionType != "" {
-		vs["client_assertion_type"] = []string{clientAssertionType}
-	}
-	if clientAssertion != "" {
-		vs["client_assertion"] = []string{clientAssertion}
-	}
-	if clientId != "" {
-		vs["client_id"] = []string{clientId}
-	}
-	if clientSecret != "" {
-		vs["client_secret"] = []string{clientSecret}
+	vs := url.Values{
+		"grant_type":            []string{string(grantType)},
+		"client_assertion_type": []string{string(clientAssertionType)},
+		"client_assertion":      []string{string(clientAssertion)},
+		"client_id":             []string{string(clientId)},
+		"client_secret":         []string{string(clientSecret)},
 	}
 	buf := vs.Encode()
 	body := bytes.NewBufferString(buf)

--- a/linebot/module_attach/api_line_module_attach.go
+++ b/linebot/module_attach/api_line_module_attach.go
@@ -221,16 +221,30 @@ func (client *LineModuleAttachAPI) AttachModuleWithHttpInfo(
 	path := "/module/auth/v1/token"
 
 	vs := url.Values{
-		"grant_type":      []string{string(grantType)},
-		"code":            []string{string(code)},
-		"redirect_uri":    []string{string(redirectUri)},
-		"code_verifier":   []string{string(codeVerifier)},
-		"client_id":       []string{string(clientId)},
-		"client_secret":   []string{string(clientSecret)},
-		"region":          []string{string(region)},
-		"basic_search_id": []string{string(basicSearchId)},
-		"scope":           []string{string(scope)},
-		"brand_type":      []string{string(brandType)},
+		"grant_type":   []string{string(grantType)},
+		"code":         []string{string(code)},
+		"redirect_uri": []string{string(redirectUri)},
+	}
+	if codeVerifier != "" {
+		vs["code_verifier"] = []string{codeVerifier}
+	}
+	if clientId != "" {
+		vs["client_id"] = []string{clientId}
+	}
+	if clientSecret != "" {
+		vs["client_secret"] = []string{clientSecret}
+	}
+	if region != "" {
+		vs["region"] = []string{region}
+	}
+	if basicSearchId != "" {
+		vs["basic_search_id"] = []string{basicSearchId}
+	}
+	if scope != "" {
+		vs["scope"] = []string{scope}
+	}
+	if brandType != "" {
+		vs["brand_type"] = []string{brandType}
 	}
 	buf := vs.Encode()
 	body := bytes.NewBufferString(buf)

--- a/linebot/module_attach/api_line_module_attach.go
+++ b/linebot/module_attach/api_line_module_attach.go
@@ -221,30 +221,16 @@ func (client *LineModuleAttachAPI) AttachModuleWithHttpInfo(
 	path := "/module/auth/v1/token"
 
 	vs := url.Values{
-		"grant_type":   []string{string(grantType)},
-		"code":         []string{string(code)},
-		"redirect_uri": []string{string(redirectUri)},
-	}
-	if codeVerifier != "" {
-		vs["code_verifier"] = []string{codeVerifier}
-	}
-	if clientId != "" {
-		vs["client_id"] = []string{clientId}
-	}
-	if clientSecret != "" {
-		vs["client_secret"] = []string{clientSecret}
-	}
-	if region != "" {
-		vs["region"] = []string{region}
-	}
-	if basicSearchId != "" {
-		vs["basic_search_id"] = []string{basicSearchId}
-	}
-	if scope != "" {
-		vs["scope"] = []string{scope}
-	}
-	if brandType != "" {
-		vs["brand_type"] = []string{brandType}
+		"grant_type":      []string{string(grantType)},
+		"code":            []string{string(code)},
+		"redirect_uri":    []string{string(redirectUri)},
+		"code_verifier":   []string{string(codeVerifier)},
+		"client_id":       []string{string(clientId)},
+		"client_secret":   []string{string(clientSecret)},
+		"region":          []string{string(region)},
+		"basic_search_id": []string{string(basicSearchId)},
+		"scope":           []string{string(scope)},
+		"brand_type":      []string{string(brandType)},
 	}
 	buf := vs.Encode()
 	body := bytes.NewBufferString(buf)


### PR DESCRIPTION
This resolves https://github.com/line/line-bot-sdk-go/issues/464 ~~with PR https://github.com/line/line-openapi/pull/70~~

## Changes

We are customizing SDK code generation to generate code that directly passes arguments to functions, instead of using a request body struct for the API.
As a result, we are unable to use the "omitempty" tag to ignore fields with empty strings.

To address this issue, we will modify the code to exclude optional string fields from url.Values when they are empty.
