### PR TITLE
Add tests for ignore-empty series

### DIFF
--- a/linebot/channel_access_token/tests/handwritten/api_IssueStatelessChannelToken_test.go
+++ b/linebot/channel_access_token/tests/handwritten/api_IssueStatelessChannelToken_test.go
@@ -1,0 +1,94 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/line/line-bot-sdk-go/v8/linebot/channel_access_token"
+)
+
+func TestIssueStatelessChannelTokenWithHttpInfo(t *testing.T) {
+	tests := []struct {
+		name                string
+		grantType           string
+		clientAssertionType string
+		clientAssertion     string
+		clientId            string
+		clientSecret        string
+		expectedFormData    url.Values
+	}{
+		{
+			name:                "Using client assertion",
+			grantType:           "client_credentials",
+			clientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+			clientAssertion:     "assertion",
+			clientId:            "",
+			clientSecret:        "",
+			expectedFormData: url.Values{
+				"grant_type":            {"client_credentials"},
+				"client_assertion_type": {"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"},
+				"client_assertion":      {"assertion"},
+			},
+		},
+		{
+			name:                "Using clientId and clientSecret",
+			grantType:           "client_credentials",
+			clientAssertionType: "",
+			clientAssertion:     "",
+			clientId:            "client_id",
+			clientSecret:        "client_secret",
+			expectedFormData: url.Values{
+				"grant_type":    {"client_credentials"},
+				"client_id":     {"client_id"},
+				"client_secret": {"client_secret"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("Failed to parse form: %v", err)
+				}
+				if !reflect.DeepEqual(r.PostForm, tt.expectedFormData) {
+					t.Errorf("Expected form data: %v, got: %v", tt.expectedFormData, r.PostForm)
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(channel_access_token.IssueStatelessChannelAccessTokenResponse{
+					AccessToken: "test_token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+			}))
+			defer mockServer.Close()
+
+			client, err := channel_access_token.NewChannelAccessTokenAPI(
+				channel_access_token.WithEndpoint(mockServer.URL),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create client: %v", err)
+			}
+
+			_, result, err := client.IssueStatelessChannelTokenWithHttpInfo(
+				tt.grantType,
+				tt.clientAssertionType,
+				tt.clientAssertion,
+				tt.clientId,
+				tt.clientSecret,
+			)
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if result.AccessToken != "test_token" {
+				t.Errorf("Expected AccessToken: test_token, got: %s", result.AccessToken)
+			}
+		})
+	}
+}

--- a/linebot/messaging_api/tests/handwritten/api_GetMembersIds_test.go
+++ b/linebot/messaging_api/tests/handwritten/api_GetMembersIds_test.go
@@ -1,0 +1,70 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/line/line-bot-sdk-go/v8/linebot/messaging_api"
+)
+
+func TestGetGroupMembersIdsWithHttpInfo(t *testing.T) {
+	tests := []struct {
+		name                string
+		groupId             string
+		start               string
+		expectedQueryParams url.Values
+	}{
+		{
+			name:    "With start token",
+			groupId: "testGroup",
+			start:   "start",
+			expectedQueryParams: url.Values{
+				"start": {"start"},
+			},
+		},
+		{
+			name:                "Without start token",
+			groupId:             "testGroup",
+			start:               "",
+			expectedQueryParams: url.Values{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !reflect.DeepEqual(r.URL.Query(), tt.expectedQueryParams) {
+					t.Fatalf("Expected query: %v, got: %v", tt.expectedQueryParams, r.URL.Query())
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(messaging_api.MembersIdsResponse{MemberIds: []string{"member1", "member2"}, Next: "abcdef"})
+			}))
+			defer mockServer.Close()
+
+			client, err := messaging_api.NewMessagingApiAPI(
+				"channelToken",
+				messaging_api.WithEndpoint(mockServer.URL),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create client: %v", err)
+			}
+
+			_, result, err := client.GetGroupMembersIdsWithHttpInfo(tt.groupId, tt.start)
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(result.MemberIds, []string{"member1", "member2"}) {
+				t.Errorf("Expected MemberIds: [\"member1\", \"member2\"], got: %s", result.MemberIds)
+			}
+			if result.Next != "abcdef" {
+				t.Errorf("Expected Next: abcdef, got: %s", result.Next)
+			}
+		})
+	}
+}

--- a/linebot/messaging_api/tests/handwritten/model_limit_test.go
+++ b/linebot/messaging_api/tests/handwritten/model_limit_test.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/line/line-bot-sdk-go/v8/linebot/messaging_api"
+)
+
+func TestLimitSerialization(t *testing.T) {
+	tests := []struct {
+		name     string
+		limit    messaging_api.Limit
+		expected string
+	}{
+		{
+			name:     "Max is set",
+			limit:    messaging_api.Limit{Max: 10, UpToRemainingQuota: true},
+			expected: `{"max":10,"upToRemainingQuota":true}`,
+		},
+		{
+			name:     "Max is zero (omitempty)",
+			limit:    messaging_api.Limit{Max: 0, UpToRemainingQuota: true},
+			expected: `{"upToRemainingQuota":true}`,
+		},
+		{
+			name:     "Max is zero and UpToRemainingQuota is false",
+			limit:    messaging_api.Limit{Max: 0, UpToRemainingQuota: false},
+			expected: `{"upToRemainingQuota":false}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.limit)
+			if err != nil {
+				t.Fatalf("Failed to marshal Limit: %v", err)
+			}
+			if string(data) != tt.expected {
+				t.Errorf("Expected JSON: %s, got: %s", tt.expected, string(data))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds tests for these changes to correctly ignore empty values.

- https://github.com/line/line-bot-sdk-go/pull/496
- https://github.com/line/line-bot-sdk-go/pull/497
- https://github.com/line/line-bot-sdk-go/pull/498