### PR TITLE
Fix godoc

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
@@ -94,7 +94,7 @@ func (client *{{ classname }}) Url(endpointPath string) string {
 	return u.String()
 }
 
-// WithHTTPClient function
+// With{{ classname contains "Blob" ? "Blob" : "" }}HTTPClient function
 func With{{ classname contains "Blob" ? "Blob" : "" }}HTTPClient(c *http.Client) {{classname}}Option {
 	return func(client *{{ classname }}) error {
 		client.httpClient = c
@@ -102,7 +102,7 @@ func With{{ classname contains "Blob" ? "Blob" : "" }}HTTPClient(c *http.Client)
 	}
 }
 
-// WithEndpointClient function
+// With{{ classname contains "Blob" ? "Blob" : "" }}Endpoint function
 func With{{ classname contains "Blob" ? "Blob" : "" }}Endpoint(endpoint string) {{classname}}Option {
 	return func(client *{{ classname }}) error {
         u, err := url.ParseRequestURI(endpoint)

--- a/linebot/channel_access_token/api_channel_access_token.go
+++ b/linebot/channel_access_token/api_channel_access_token.go
@@ -92,7 +92,7 @@ func WithHTTPClient(c *http.Client) ChannelAccessTokenAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) ChannelAccessTokenAPIOption {
 	return func(client *ChannelAccessTokenAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/insight/api_insight.go
+++ b/linebot/insight/api_insight.go
@@ -102,7 +102,7 @@ func WithHTTPClient(c *http.Client) InsightAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) InsightAPIOption {
 	return func(client *InsightAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/liff/api_liff.go
+++ b/linebot/liff/api_liff.go
@@ -103,7 +103,7 @@ func WithHTTPClient(c *http.Client) LiffAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) LiffAPIOption {
 	return func(client *LiffAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/manage_audience/api_manage_audience.go
+++ b/linebot/manage_audience/api_manage_audience.go
@@ -104,7 +104,7 @@ func WithHTTPClient(c *http.Client) ManageAudienceAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) ManageAudienceAPIOption {
 	return func(client *ManageAudienceAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/manage_audience/api_manage_audience_blob.go
+++ b/linebot/manage_audience/api_manage_audience_blob.go
@@ -97,7 +97,7 @@ func (client *ManageAudienceBlobAPI) Url(endpointPath string) string {
 	return u.String()
 }
 
-// WithHTTPClient function
+// WithBlobHTTPClient function
 func WithBlobHTTPClient(c *http.Client) ManageAudienceBlobAPIOption {
 	return func(client *ManageAudienceBlobAPI) error {
 		client.httpClient = c
@@ -105,7 +105,7 @@ func WithBlobHTTPClient(c *http.Client) ManageAudienceBlobAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithBlobEndpoint function
 func WithBlobEndpoint(endpoint string) ManageAudienceBlobAPIOption {
 	return func(client *ManageAudienceBlobAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/messaging_api/api_messaging_api.go
+++ b/linebot/messaging_api/api_messaging_api.go
@@ -104,7 +104,7 @@ func WithHTTPClient(c *http.Client) MessagingApiAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) MessagingApiAPIOption {
 	return func(client *MessagingApiAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/messaging_api/api_messaging_api_blob.go
+++ b/linebot/messaging_api/api_messaging_api_blob.go
@@ -95,7 +95,7 @@ func (client *MessagingApiBlobAPI) Url(endpointPath string) string {
 	return u.String()
 }
 
-// WithHTTPClient function
+// WithBlobHTTPClient function
 func WithBlobHTTPClient(c *http.Client) MessagingApiBlobAPIOption {
 	return func(client *MessagingApiBlobAPI) error {
 		client.httpClient = c
@@ -103,7 +103,7 @@ func WithBlobHTTPClient(c *http.Client) MessagingApiBlobAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithBlobEndpoint function
 func WithBlobEndpoint(endpoint string) MessagingApiBlobAPIOption {
 	return func(client *MessagingApiBlobAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/module/api_line_module.go
+++ b/linebot/module/api_line_module.go
@@ -104,7 +104,7 @@ func WithHTTPClient(c *http.Client) LineModuleAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) LineModuleAPIOption {
 	return func(client *LineModuleAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/module_attach/api_line_module_attach.go
+++ b/linebot/module_attach/api_line_module_attach.go
@@ -102,7 +102,7 @@ func WithHTTPClient(c *http.Client) LineModuleAttachAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) LineModuleAttachAPIOption {
 	return func(client *LineModuleAttachAPI) error {
 		u, err := url.ParseRequestURI(endpoint)

--- a/linebot/shop/api_shop.go
+++ b/linebot/shop/api_shop.go
@@ -102,7 +102,7 @@ func WithHTTPClient(c *http.Client) ShopAPIOption {
 	}
 }
 
-// WithEndpointClient function
+// WithEndpoint function
 func WithEndpoint(endpoint string) ShopAPIOption {
 	return func(client *ShopAPI) error {
 		u, err := url.ParseRequestURI(endpoint)


### PR DESCRIPTION
Fix godoc for `WithHTTPClient` and `WithEndpoint`.

- Fix pebble template
- Run `python3 generate-code.py`

Fixes #539.