### PR TITLE
Migrate renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,10 @@
         'dependency upgrade',
         'line-openapi-update',
       ],
+      // In many cases, we would like to update line-openapi by dispatching the GitHub workflow during working
+      // hours, as there are code changes.
+      // If that is forgotten, there's a possibility that line-openapi updates or code changes won't happen at
+      // all, so we allow it to run at night just in case.
       schedule: [
         'after 11pm',
         'before 4am',

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,35 +1,31 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver"
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:recommended',
+    'helpers:pinGitHubActionDigestsToSemver',
   ],
-  "timezone": "Asia/Tokyo",
-  "automerge": true,
-  "platformAutomerge": true,
-  "git-submodules": {
-    "enabled": true
+  timezone: 'Asia/Tokyo',
+  automerge: true,
+  platformAutomerge: true,
+  'git-submodules': {
+    enabled: true,
   },
-  "labels": [
-    "dependency upgrade"
+  labels: [
+    'dependency upgrade',
   ],
-  "packageRules": [
+  packageRules: [
     {
-      "matchPackagePatterns": [
-        "line-openapi"
+      labels: [
+        'dependency upgrade',
+        'line-openapi-update',
       ],
-      "labels": [
-        "dependency upgrade",
-        "line-openapi-update"
+      schedule: [
+        'after 11pm',
+        'before 4am',
       ],
-      // In many cases, we would like to update line-openapi by dispatching the GitHub workflow during working
-      // hours, as there are code changes.
-      // If that is forgotten, there's a possibility that line-openapi updates or code changes won't happen at
-      // all, so we allow it to run at night just in case.
-      "schedule": [
-        "after 11pm",
-        "before 4am"
-      ]
+      matchPackageNames: [
+        '/line-openapi/',
+      ],
     },
-  ]
+  ],
 }


### PR DESCRIPTION
Renovate's auto migrator removes comments and disrupts the format as it said.
This change keeps the original file as much as possible.

Close https://github.com/line/line-bot-sdk-go/pull/558