### PR TITLE
Fix TextMessageV2 struct field Substitution to interface

### DIFF
--- a/linebot/messaging_api/model_text_message_v2.go
+++ b/linebot/messaging_api/model_text_message_v2.go
@@ -47,7 +47,7 @@ type TextMessageV2 struct {
 	/**
 	 * A mapping that specifies substitutions for parts enclosed in {} within the `text` field.
 	 */
-	Substitution map[string]SubstitutionObject `json:"substitution,omitempty"`
+	Substitution map[string]SubstitutionObjectInterface `json:"substitution,omitempty"`
 
 	/**
 	 * Quote token of the message you want to quote.


### PR DESCRIPTION
change TextMessageV2 struct field Substitution from SubstitutionObject to SubstitutionObjectInterface