### PR TITLE
Require more jobs in merge queue

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -1,11 +1,10 @@
 name: Generate code and open pull request
 
 on:
-  workflow_dispatch:
-  pull_request:
   push:
-    branches:
-      - master
+  pull_request:
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,11 +1,10 @@
-name: Go
+name: Go Test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
   merge_group:
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
To re-enable the merge queue, this change adds merge_group to several jobs.

original: https://github.com/line/line-bot-sdk-java/pull/1592