### PR TITLE
Do not create another auto PR when a job runs for PR

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -2,6 +2,8 @@ name: Generate code and open pull request
 
 on:
   push:
+    branches:
+      - 'master'
   pull_request:
   merge_group:
   workflow_dispatch:


### PR DESCRIPTION
`.github/workflows/generate-code.yml` creates another PR when the submitted PR has diff ... 😄 
This change fixes it.