### PR TITLE
Use stable and oldstable instead actual version for actions/setup-go

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24'
+          go-version: stable
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         go:
-        - '1.23'
-        - '1.24'
+        - stable
+        - oldstable
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:


### PR DESCRIPTION
`actions/setup-go` provides aliases for active 2 Go versions. With this, we don't have to maintain go version for github actions workflows like https://github.com/line/line-bot-sdk-go/pull/471/files and https://github.com/line/line-bot-sdk-go/pull/578/files.

reference: https://github.com/actions/setup-go/blob/d35c59abb061a4a6fb18e82ac0862c26744d6ab5/README.md?plain=1#L134-L161