### PR TITLE
Fix pebble for array-type query parameter

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-go-generator/api.pebble
@@ -277,7 +277,11 @@ func (client *{{ classname }}) {{ op.operationId }}WithHttpInfo(
     {% if op.hasQueryParams -%}
 	query := url.Values{}
 	    {% for qp in op.queryParams -%}
-            {% if qp.isString and not qp.required -%}
+            {% if qp.isArray -%}
+    for _, v := range *{{ qp.paramName }} {
+    query.Add("{{ qp.paramName }}", v)
+    }
+            {% elseif qp.isString and not qp.required -%}
     if {{ stringify(qp) }} != "" {
     query.Add("{{ qp.paramName }}", {{ stringify(qp) }})
     }


### PR DESCRIPTION
## Description
This PR addresses a modification to the generator responsible for producing the Go SDK from OpenAPI definitions. Specifically, it introduces support for query parameters that include arrays.

## Changes
Enhanced the generator to handle array-type query parameters.

Here is an example of how such an API call might look in a shell script:
```sh
curl -X GET "https://api.line.me/v2/bot/example?param=value1&param=value2"
```

## Note
Currently, there are no endpoints that utilize such parameters. However, this update is a preparatory step for future API enhancements.