### PR TITLE
Use github actor id instead of bot name to avoid renaming issues

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -47,7 +47,7 @@ jobs:
           ${{
             (github.event_name == 'pull_request' || github.event_name == 'merge_group')
             && env.DIFF_IS_EMPTY != 'true'
-            && github.actor_id != 29139614
+            && github.actor_id != '29139614'
           }}
         run: |
           echo "There are changes in the generated codes. Please run 'generate-code.py' and commit the changes." >&2

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -42,11 +42,12 @@ jobs:
           echo "DIFF_IS_EMPTY=$([[ -z "$diff_excluding_submodule" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
           echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
       ## Run if diff exists and pull request or merge queue, and make CI status failure (but allow renovate bot)
+      ## 29139614 is renovate bot's actor id
       - if: >-
           ${{
             (github.event_name == 'pull_request' || github.event_name == 'merge_group')
             && env.DIFF_IS_EMPTY != 'true'
-            && github.actor != 'renovate[bot]'
+            && github.actor_id != 29139614
           }}
         run: |
           echo "There are changes in the generated codes. Please run 'generate-code.py' and commit the changes." >&2


### PR DESCRIPTION
This PR modifies the GitHub Actions workflow to use the GitHub actor ID instead of the bot name. This change helps avoid issues related to renaming the bot, ensuring that the workflow continues to function correctly even if the bot's name changes.
 See https://github.com/renovatebot/renovate/discussions/37842.

https://api.github.com/users/renovate%5Bbot%5D
> {
>   "login": "renovate[bot]",
>   "id": 29139614,
>   ...
> }



Parent PR: https://github.com/line/line-bot-sdk-nodejs/pull/1399
