### PR TITLE
Support Go 1.25 and drop 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the official API documentation for more information.
 
 ## Requirements
 
-This library requires Go 1.23 or later.
+This library requires Go 1.24 or later.
 
 ## Installation ##
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/line/line-bot-sdk-go/v8
 
-go 1.23
+go 1.24


### PR DESCRIPTION
Drop Go 1.23
No changes are required to support Go 1.25.
https://endoflife.date/go

Close #609 #610 